### PR TITLE
mcp-ci: test the declared Node floor

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -61,13 +61,24 @@ jobs:
       - run: npm run typecheck && npm run typecheck:tests
       - run: npm run lint
 
+  # Two lanes on purpose. package.json declares engines >=24.0.0, so 24 is the
+  # floor a user may actually run the published package on; 26 is what the
+  # release toolchain builds with. Testing only the newest would let the
+  # declared floor rot untested until someone on Node 24 hit it first.
   test:
+    name: test (Node ${{ matrix.node_version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version:
+          - '24'
+          - '26'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '26'
+          node-version: ${{ matrix.node_version }}
           cache: npm
           cache-dependency-path: fluentcart-mcp/package-lock.json
       - run: npm ci


### PR DESCRIPTION
After the Node sweep every lane ran on 26, which left `fluentcart-mcp` in an awkward position: `package.json` declares `engines: >=24.0.0`, so Node 24 is what a user may actually run the published package on, and nothing tested it.

A declared minimum nobody exercises is a claim rather than a guarantee. The first person to discover it had rotted would have been someone on Node 24, at runtime, with a stack trace.

So the `test` job becomes a matrix over 24 and 26. `fail-fast: false`, so one lane failing still reports the other rather than hiding it. `conformance` and `protocol` both `needs: test` and now wait for both legs, which is the behaviour you want.

Smoke-tested on Node 24 before pushing — 2823 unit and 404/405 tooling, the single failure being the stale gitignored `dist-packages` fixture from 31 July that does not exist on a runner. The lane contract tests assert content (`npm run test:unit`, `npm run test:tooling`) rather than job names, so the matrix leaves them alone.

The obvious follow-up, deliberately not taken here: raising `engines` to `>=26.0.0` instead. That narrows what users can run, which is a product decision rather than a CI one. If it is ever taken, this matrix is the thing to delete, in the same commit.