### PR TITLE
web-docs: unbreak the Docker build

### DIFF
--- a/web-docs/Dockerfile
+++ b/web-docs/Dockerfile
@@ -1,5 +1,8 @@
 # Stage 1: Install dependencies
-FROM oven/bun:1 AS deps
+# Bun is a superb package manager, and this stage is all it does — install.
+# Pinned rather than floating on "1": a base image that moves under you is how
+# a build that worked on Friday segfaults on Monday with nothing to blame.
+FROM oven/bun:1.3.14-slim AS deps
 WORKDIR /app
 
 # Copy package files, lockfile, and files needed for fumadocs-mdx postinstall
@@ -10,7 +13,11 @@ COPY content ./content
 RUN bun install --frozen-lockfile
 
 # Stage 2: Build the application
-FROM oven/bun:1 AS builder
+# Node, not Bun. Bun panics on teardown after `next build` completes, turning a
+# finished build into exit code 132 — the artefacts are fine, the process is
+# not, and CI cannot tell the difference. Node runs Next the way Next expects.
+# Debian-based, matching the deps stage's libc so native binaries stay valid.
+FROM node:26-slim AS builder
 WORKDIR /app
 
 # Build-time variables (NEXT_PUBLIC_* must be set at build time!)
@@ -28,11 +35,14 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_URL=${NEXT_PUBLIC_URL}
 
-# Build Next.js application
-RUN bun run build
+# Build Next.js directly rather than through `bun run build`, so the package
+# script stays Bun's for local work while the image never hands Next to Bun.
+RUN node ./node_modules/next/dist/bin/next build
 
-# Stage 3: Production runner (Alpine is small and has user management tools)
-FROM oven/bun:1-alpine AS runner
+# Stage 3: Production runner
+# Debian again, so the native binaries traced into the standalone bundle meet
+# the same libc they were installed against. Alpine plus glibc deps is a bet.
+FROM node:26-slim AS runner
 WORKDIR /app
 
 # Set production environment
@@ -41,9 +51,9 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
-# Create non-root user for security (Alpine syntax)
-RUN addgroup -S -g 1001 nodejs && \
-    adduser -S -u 1001 -G nodejs nextjs
+# Create non-root user for security (the stock `node` user already holds 1000)
+RUN groupadd -g 1001 nodejs && \
+    useradd -u 1001 -g nodejs -m -s /usr/sbin/nologin nextjs
 
 # Copy only necessary files from builder
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
@@ -56,9 +66,11 @@ USER nextjs
 # Expose port
 EXPOSE 3000
 
-# Health check using wget with IPv4 (Alpine's wget tries IPv6 first which fails)
+# Health check through Node itself, pinned to IPv4. The slim images carry
+# neither wget nor curl, and the previous IPv6-first wget was already a
+# workaround for exactly this.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/ || exit 1
+  CMD node -e "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 # Start the application
-CMD ["bun", "server.js"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
This started as tidying and turned out to be a fix. **The docs image does not currently build from `main`:**

```
error: script "build" was terminated by signal SIGTRAP (Trace or breakpoint trap)
ERROR: process "/bin/sh -c bun run build" did not complete successfully: exit code: 133
```

Nothing in the repository changed to cause that. The base was `oven/bun:1` — a floating tag — which has since become 1.3.x, and Bun panics on teardown once `next build` finishes. The artefacts are written; the process dies on the way out; Docker sees only a non-zero exit. A tag that promised stability moved underneath the build.

I verified this by building `main`'s Dockerfile unmodified, rather than taking the failure mode on trust. It fails reproducibly.

## What changes

**Builder and runner become `node:26-slim`.** Node runs Next the way Next expects to be run, and 26 is what the rest of CI standardised on this week. Next is invoked directly — `node ./node_modules/next/dist/bin/next build` — so the `package.json` script stays Bun's for local work while the image never hands Next to Bun at all.

**Bun keeps the deps stage**, which is the thing it is genuinely excellent at, now pinned to `1.3.14-slim` instead of floating. Worth noting the panic does not affect installing: I tested the current Bun in that role and it is fine. Only `next build` was ever the problem.

**Debian throughout.** The old runner was Alpine with glibc-built dependencies copied into it, which is a bet rather than a configuration. Same libc across stages means the native binaries traced into the standalone bundle meet the one they were installed against.

**Health check moves from `wget` to `node -e fetch`.** The slim images ship neither `wget` nor `curl`. The old command already carried an IPv4 workaround (`--no-verbose`, explicit 127.0.0.1) for the same class of problem, so this is the same intent with a tool that exists.

## Verified by running it, not by reading it

| Check | Result |
|---|---|
| `docker build` | clean |
| Container status | `Up (healthy)` — the new HEALTHCHECK genuinely passes |
| `/` | 200, 124 kB |
| `/contact` | 200 |
| `/docs/fchub-memberships` | 200 |
| `/docs/cartshift` | 200 |
| `id` inside the container | `uid=1001(nextjs) gid=1001(nodejs)` — non-root preserved |

A bare `/docs` returns 404, which is the app's own routing and true on `main` too — there is no page at that path.

## One judgement call

This arrived as an unreported change bundled into a dependency-migration branch, and I pulled it out precisely because it rewrites the production deployment image. It gets its own PR, its own build, and its own evidence. It also originally pinned `node:24`, three commits after the repository moved to 26; that is corrected here.