### PR TITLE
fchub-portal-extender: close the nanoid advisory

### DIFF
--- a/plugins/fchub-portal-extender/package-lock.json
+++ b/plugins/fchub-portal-extender/package-lock.json
@@ -1760,9 +1760,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1850,7 +1850,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/plugins/fchub-portal-extender/package.json
+++ b/plugins/fchub-portal-extender/package.json
@@ -22,6 +22,6 @@
   "overrides": {
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "postcss": "8.5.23"
+    "postcss": "8.5.26"
   }
 }


### PR DESCRIPTION
A new high-severity advisory landed after tonight's merges: **GHSA-2v37-7h3g-55p8**, `nanoid` below 3.3.17.

It was not reachable by bumping a direct dependency. `nanoid` sits underneath `postcss`, which this package pins to an exact `8.5.23` in `overrides` — so the pin that was there to control one thing was holding back another. Moving the override to `8.5.26` resolves `nanoid` to **3.3.18**.

`npm audit`: 1 high → **0**.

The bundle rebuilds, so the committed `assets/dist/` hashes churn. Safe: `AdminMenu.php` resolves entries through `assets/dist/.vite/manifest.json` at runtime rather than hardcoding names, and the regenerated manifest still carries both the `resources/admin/main.js` entry and the `style.css` fallback it reads.

The same advisory raised four alerts against `fchub-stream`. Those are dismissed as `not_used` — discontinued, not built, not released.