### PR TITLE
web-docs: stop tracking the file next dev writes

### DIFF
--- a/web-docs/.gitignore
+++ b/web-docs/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 .vercel
 next-env.d.ts
 .mcp.json
+# Written by `next dev` on every run; not a source file.
+AGENTS.md

--- a/web-docs/AGENTS.md
+++ b/web-docs/AGENTS.md
@@ -1,9 +1,0 @@
-<!-- BEGIN:nextjs-agent-rules -->
-
-# This is NOT the Next.js you know
-
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
-
-This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
-
-<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
`web-docs/AGENTS.md` is written by `next dev` itself — `node_modules/next/dist/server/lib/generate-agent-files.js` — and I committed it by accident in #122, having run the dev server to get an unminified error message.

It is not a source file, nobody asked for it, and Next rewrites it on every `next dev`. Untracked and added to `.gitignore`, so it can keep being regenerated locally without appearing in diffs.