### PR TITLE
docs-ci: build the site

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -77,6 +77,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The site has to actually build. Every check below this one reads content
+  # and compares it against something; none of them run Next, which is how a
+  # docs site that cannot be built sat on main behind a green tick. Two real
+  # breakages hid here: a floating base-image tag that took the Docker build
+  # with it, and a duplicated @base-ui/react that left a React context
+  # unresolvable at prerender. Both were invisible to every gate in this file.
+  build:
+    name: Site builds
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-docs
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
+      # --frozen-lockfile on purpose: the committed lockfile is what deploys,
+      # so a build that only passes after resolution drifts is not a pass.
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      # Node, not bun, and Next invoked directly — the same command
+      # web-docs/Dockerfile runs, so this gate exercises the path that ships
+      # rather than a convenient local approximation. NEXT_PUBLIC_URL matches
+      # the Dockerfile's default for the same reason.
+      - name: Build
+        env:
+          NODE_ENV: production
+          NEXT_TELEMETRY_DISABLED: '1'
+          NEXT_PUBLIC_URL: https://fchub.co
+        run: node ./node_modules/next/dist/bin/next build
+
   consistency:
     name: Version Consistency
     runs-on: ubuntu-latest

--- a/.github/workflows/fchub-ci-contract.test.mjs
+++ b/.github/workflows/fchub-ci-contract.test.mjs
@@ -207,6 +207,15 @@ test('Docs CI watches the FCHub sources its own checks read', () => {
   const consistency = job(docs, 'consistency')
   assert.match(consistency, /node scripts\/check-fchub-docs\.mjs/)
   assert.match(consistency, /node scripts\/sync-fchub-catalog\.mjs --check/)
+
+  // Every other check in Docs CI reads content and compares it to something.
+  // None of them runs Next, which is how a site that could not be built sat
+  // on main behind a green tick. Pinned so the gate cannot quietly go away:
+  // it must run the same command the Dockerfile does, on the committed
+  // lockfile, or it is testing something other than what deploys.
+  const build = job(docs, 'build')
+  assert.match(build, /bun install --frozen-lockfile/)
+  assert.match(build, /node \.\/node_modules\/next\/dist\/bin\/next build/)
 })
 
 /**


### PR DESCRIPTION
Every check in Docs CI reads content and compares it against something. None of them ran Next.

That is how a docs site that could not be built sat on `main` behind a green tick — **twice tonight**. A floating `oven/bun:1` tag that took the Docker build with it, and a duplicated `@base-ui/react` that left a React context unresolvable at prerender. Neither was visible to a single gate in this workflow.

## What it does

A separate `build` job, so it runs alongside the content checks and a failure tells you which half broke.

- **`bun install --frozen-lockfile`** — the committed lockfile is what deploys. A build that only passes once resolution drifts is not a pass, and that drift is precisely what hid the base-ui duplication.
- **`node ./node_modules/next/dist/bin/next build`** — the same command `web-docs/Dockerfile` runs, with the same `NEXT_PUBLIC_URL`. Gating the path that ships rather than a convenient local approximation. Bun installs; Node builds.
- Bun pinned to 1.3.14, Node to 26, matching the Dockerfile and the rest of CI.

No exact page count is asserted. The build failing is the signal; pinning 223 would just break every time a page is added.

## Pinned so it cannot quietly go away

`fchub-ci-contract.test.mjs` now asserts the job runs both commands. Mutation-checked rather than assumed: replacing the build step with an `echo` fails the contract.

Had this existed this morning, both of tonight's breakages would have failed on the commit that introduced them instead of being found by hand.