### PR TITLE
cartshift: one product-type predicate, four callers

### DIFF
--- a/plugins/cartshift/app/Domain/Scope/ScopeConsequences.php
+++ b/plugins/cartshift/app/Domain/Scope/ScopeConsequences.php
@@ -8,6 +8,7 @@ defined('ABSPATH') || exit;
 
 use CartShift\Domain\Mapping\CouponMapper;
 use CartShift\Support\Enums\MigrationErrorCode;
+use CartShift\Support\ProductTypes;
 use CartShift\Support\WooStorage;
 use CartShift\Validator\PreflightCheck;
 
@@ -25,15 +26,16 @@ use CartShift\Validator\PreflightCheck;
  *    than its product, and a coupon restricted to products nobody picked.
  *
  *  - Losses the migrators cause under *every* scope. ProductMigrator sources
- *    only the supported product types (see
- *    PreflightCheck::SUPPORTED_PRODUCT_TYPES), so a subscription selling a
- *    LearnDash `course`, or a coupon restricted to one, is left behind just as
- *    surely under a plain "Everything" run. Gating those counts on
- *    MODE_EXPLICIT on the premise that "the whole catalogue travels" reported
- *    zero in exactly the run where the owner had asked for no narrowing at all.
+ *    only the supported product types (see \CartShift\Support\ProductTypes),
+ *    so a subscription selling a LearnDash `course`, or a coupon restricted to
+ *    one, is left behind just as surely under a plain "Everything" run. Gating
+ *    those counts on MODE_EXPLICIT on the premise that "the whole catalogue
+ *    travels" reported zero in exactly the run where the owner had asked for no
+ *    narrowing at all.
  *
- * Which product types are unsupported comes from PreflightCheck and nowhere
- * else, and which coupon restriction losses disable a coupon comes from
+ * Which products are unmigratable comes from ProductTypes and nowhere else —
+ * as the literal complement of the migrator's own predicate, not a lookalike —
+ * and which coupon restriction losses disable a coupon comes from
  * CouponMapper::WIDENING_ON_TOTAL_LOSS and nowhere else. Both are read, never
  * re-listed: a preview that disagreed with the migrator it is previewing is
  * the failure mode this whole class exists to avoid.
@@ -139,8 +141,8 @@ final class ScopeConsequences
      * Scope-aware through productPredicate(), so an explicit pick that happens
      * to contain no unmigratable product correctly reports zero, while
      * "Everything" reports the whole catalogue's worth. Same status trio and
-     * same unsupported-slug list as everything else — see
-     * PreflightCheck::SUPPORTED_PRODUCT_TYPES.
+     * the same type predicate as everything else — see
+     * \CartShift\Support\ProductTypes.
      *
      * No remedy: nothing the owner can add to the scope makes a `course`
      * migratable. The honest move is to say so and let them decide.
@@ -193,11 +195,12 @@ final class ScopeConsequences
      * true figure. Widening it is a later task (see task-8 report).
      *
      * Which types are "unrecognised" also comes from PreflightCheck —
-     * unsupportedProductTypeCounts() — rather than a second copy of the
-     * supported-type list kept here. See PreflightCheck::SUPPORTED_PRODUCT_TYPES
-     * for why there must be only one: a preflight warning and a consequence
-     * count that disagreed about which types are unsupported would be quoted
-     * side by side to the same user.
+     * unsupportedProductTypeCounts(), itself the difference between this
+     * catalogue and \CartShift\Support\ProductTypes — rather than a second copy
+     * of the supported-type list kept here. See that class for why there must
+     * be only one: a preflight warning and a consequence count that disagreed
+     * about which types are unsupported would be quoted side by side to the
+     * same user.
      *
      * The lower-bound caveat above is not just a comment for the next PHP
      * author — it travels on the wire. all() passes `isMinimum: true` for
@@ -286,11 +289,10 @@ final class ScopeConsequences
      *    product type, so a course product sitting inside the closure counted
      *    as fine.
      *
-     * The unsupported types come from PreflightCheck — see
-     * PreflightCheck::SUPPORTED_PRODUCT_TYPES for why there must be only one
-     * such list — and are applied in SQL rather than by fetching every
-     * in-scope subscription and filtering in PHP, which on an "Everything" run
-     * means every subscription in the shop.
+     * The type predicate comes from \CartShift\Support\ProductTypes — see that
+     * class for why there must be only one — and is applied in SQL rather than
+     * by fetching every in-scope subscription and filtering in PHP, which on an
+     * "Everything" run means every subscription in the shop.
      *
      * @return list<array{code: string, label: string, hint: string, severity: string, category: string, count: int, remedy: array{action: string, label: string, product_ids?: list<int>}|null}>
      */
@@ -547,7 +549,7 @@ final class ScopeConsequences
      * Three ways to fail, all of them reasons CouponMapper's ID map lookup
      * comes back empty: the post is gone or trashed, its product_type is one
      * ProductMigrator does not source, or — explicit scopes only — it is
-     * outside the closure. The type list is PreflightCheck's, never a copy.
+     * outside the closure. The type predicate is ProductTypes', never a copy.
      *
      * @param list<int> $ids
      * @return list<int>
@@ -620,43 +622,32 @@ final class ScopeConsequences
     }
 
     /**
-     * `<column> IN (every product of a type CartShift cannot migrate)`.
+     * `<column> is a product CartShift would NOT migrate`.
      *
-     * Empty SQL when the shop has no unsupported types at all, so the caller
-     * can drop the clause entirely rather than emit `IN ()`.
+     * The exact complement of the predicate the migrator counts and fetches
+     * with — ProductTypes::unmigratableClause() is literally `NOT (that)` — so
+     * a row this reports as lost is a row the migrator really does drop, and
+     * the reverse. It used to be an independently written `IN (the unsupported
+     * slugs this catalogue happens to use)`, which disagreed with the migrator
+     * about every product carrying no product_type term at all: this method
+     * called such a product fine, the migrator dropped it, and the panel said
+     * nothing was left behind.
      *
-     * The slug list comes from PreflightCheck::unsupportedProductTypeCounts()
-     * — the single definition, see PreflightCheck::SUPPORTED_PRODUCT_TYPES.
-     * Products carrying no product_type term at all are not matched here,
-     * which mirrors the picker's own exclusion (PreviewController) rather than
-     * ProductMigrator's positive IN list; the two differ on that edge, and
-     * that difference predates this method.
+     * Empty SQL when nothing in the shop is unmigratable, so the callers can
+     * drop the clause and skip the query entirely. That test is still
+     * PreflightCheck::unsupportedProductTypeCounts() — catalogue-dependent, and
+     * empty exactly when every term the shop uses is supported, which is
+     * exactly when no product can fail the predicate.
      *
      * @return array{0: string, 1: list<string>}
      */
     private static function unsupportedTypeClause(string $column): array
     {
-        $slugs = array_values(array_keys(PreflightCheck::unsupportedProductTypeCounts()));
-
-        if ($slugs === []) {
+        if (PreflightCheck::unsupportedProductTypeCounts() === []) {
             return ['', []];
         }
 
-        global $wpdb;
-
-        $holes = implode(', ', array_fill(0, count($slugs), '%s'));
-
-        return [
-            "{$column} IN (
-                    SELECT tr.object_id
-                      FROM {$wpdb->term_relationships} tr
-                INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
-                INNER JOIN {$wpdb->terms} t ON t.term_id = tt.term_id
-                     WHERE tt.taxonomy = 'product_type'
-                       AND t.slug IN ({$holes})
-                 )",
-            $slugs,
-        ];
+        return ProductTypes::unmigratableClause($column);
     }
 
     /**

--- a/plugins/cartshift/app/Http/Controllers/PreviewController.php
+++ b/plugins/cartshift/app/Http/Controllers/PreviewController.php
@@ -19,8 +19,8 @@ use CartShift\State\MigrationState;
 use CartShift\Storage\IdMapRepository;
 use CartShift\Storage\MigrationLogRepository;
 use CartShift\Support\Constants;
+use CartShift\Support\ProductTypes;
 use CartShift\Support\WooStorage;
-use CartShift\Validator\PreflightCheck;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -207,12 +207,18 @@ final class PreviewController
      * picked product of a type ProductMigrator does not source travels into
      * MigrationScope::productIds() unfiltered — ScopeResolver's closure does
      * not know about product types either — and only ProductMigrator's own
-     * SUPPORTED_PRODUCT_TYPES join at count/fetch time drops it, silently, as
+     * type join at count/fetch time drops it, silently, as
      * counts['product'] === 0 for a pick the owner made deliberately. The
      * picker showing it at all is the point the owner has no way to notice
-     * that decision was made. Reuses PreflightCheck::unsupportedProductTypeCounts()
-     * — see PreflightCheck::SUPPORTED_PRODUCT_TYPES for why a second copy of
-     * the supported-type list must never exist.
+     * that decision was made.
+     *
+     * The predicate is ProductTypes::migratableClause() — the same one the
+     * migrator counts and fetches with, and the same one the consequences
+     * panel takes the complement of. Not a lookalike: this used to be a
+     * hand-rolled `NOT IN (unsupported slugs)`, which agreed with the migrator
+     * on nothing in particular and disagreed with it about products carrying no
+     * product_type term and about subscription products on a store where
+     * WooCommerce Subscriptions has since been disabled.
      *
      * One extra row is asked for so truncation can be reported without a
      * second COUNT query: if the limit'th-plus-one row comes back, more
@@ -226,23 +232,7 @@ final class PreviewController
 
         $like = '%' . self::escLike($term) . '%';
 
-        $unsupportedTypes = array_keys(PreflightCheck::unsupportedProductTypeCounts());
-
-        $exclusion = '';
-        $exclusionValues = [];
-
-        if ($unsupportedTypes !== []) {
-            $placeholders = implode(', ', array_fill(0, count($unsupportedTypes), '%s'));
-
-            $exclusion = " AND p.ID NOT IN (
-                   SELECT tr.object_id FROM {$wpdb->term_relationships} tr
-                   INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-                   INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-                   WHERE tt.taxonomy = 'product_type'
-                     AND t.slug IN ({$placeholders})
-               )";
-            $exclusionValues = $unsupportedTypes;
-        }
+        [$typeSql, $typeValues] = ProductTypes::migratableClause('p.ID');
 
         $rows = (array) $wpdb->get_results($wpdb->prepare(
             "SELECT p.ID AS id, p.post_title AS title, pml.sku AS sku
@@ -250,11 +240,11 @@ final class PreviewController
              LEFT JOIN {$wpdb->prefix}wc_product_meta_lookup pml ON pml.product_id = p.ID
              WHERE p.post_type = 'product'
                AND p.post_status IN ('publish', 'draft', 'private')
-               AND (p.post_title LIKE %s OR pml.sku LIKE %s)"
-            . $exclusion
-            . " ORDER BY p.post_title ASC
+               AND (p.post_title LIKE %s OR pml.sku LIKE %s)
+               AND {$typeSql}
+             ORDER BY p.post_title ASC
              LIMIT %d",
-            ...[$like, $like, ...$exclusionValues, $limit + 1],
+            ...[$like, $like, ...$typeValues, $limit + 1],
         ), ARRAY_A);
 
         $truncated = count($rows) > $limit;

--- a/plugins/cartshift/app/Migrator/ProductMigrator.php
+++ b/plugins/cartshift/app/Migrator/ProductMigrator.php
@@ -13,6 +13,7 @@ use CartShift\Storage\IdMapRepository;
 use CartShift\Storage\MigrationLogRepository;
 use CartShift\Support\Constants;
 use CartShift\Support\Enums\MigrationErrorCode;
+use CartShift\Support\ProductTypes;
 use FluentCart\App\Models\AttributeGroup;
 use FluentCart\App\Models\AttributeRelation;
 use FluentCart\App\Models\AttributeTerm;
@@ -596,14 +597,19 @@ final class ProductMigrator extends AbstractMigrator
 
     /**
      * FIX H2: use COUNT(*) SQL query, not wc_get_products with limit=-1.
+     *
+     * The type test is ProductTypes::migratableClause() and nothing else. This
+     * method used to build its own positive `IN (supported slugs)` subquery
+     * from a private list kept here, which is how the denominator came to
+     * disagree with the picker, the preflight warning and the consequences
+     * panel all at once.
      */
     #[\Override]
     protected function countTotal(): int
     {
         global $wpdb;
 
-        $types = $this->getProductTypes();
-        $placeholders = implode(',', array_fill(0, count($types), '%s'));
+        [$typeSql, $typeValues] = ProductTypes::migratableClause('pml.product_id');
         $selection = $this->scopeResolver()->productPredicate('p.ID');
 
         return (int) $wpdb->get_var($wpdb->prepare(
@@ -612,15 +618,9 @@ final class ProductMigrator extends AbstractMigrator
              INNER JOIN {$wpdb->posts} p ON p.ID = pml.product_id
              WHERE p.post_type = 'product'
                AND p.post_status IN ('publish', 'draft', 'private')
-               AND pml.product_id IN (
-                   SELECT object_id FROM {$wpdb->term_relationships} tr
-                   INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-                   INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-                   WHERE tt.taxonomy = 'product_type'
-                     AND t.slug IN ({$placeholders})
-               )"
+               AND {$typeSql}"
             . $selection->andSql(),
-            ...[...$types, ...$selection->values()],
+            ...[...$typeValues, ...$selection->values()],
         ));
     }
 
@@ -637,8 +637,8 @@ final class ProductMigrator extends AbstractMigrator
      *
      * So the ID page comes from a direct indexed query that reuses countTotal()'s
      * exact type/status filtering — the two must agree, or the progress bar lies
-     * — and hydration goes through wc_get_products(['include' => $ids]), which
-     * primes the post caches in one pass the way the old call did.
+     * — and hydration then turns exactly those IDs into objects, filtering
+     * nothing, because the filtering already happened in SQL.
      */
     #[\Override]
     public function fetchBatch(string|int|null $cursor, int $limit): array
@@ -659,19 +659,7 @@ final class ProductMigrator extends AbstractMigrator
             $after = (int) end($ids);
             $this->pageEndCursor = $after;
 
-            $products = wc_get_products([
-                'limit'   => count($ids),
-                'include' => $ids,
-                'type'    => $this->getProductTypes(),
-                'status'  => ['publish', 'draft', 'private'],
-                'orderby' => 'ID',
-                'order'   => 'ASC',
-            ]);
-
-            $products = array_values(array_filter(
-                (array) $products,
-                static fn (mixed $product): bool => is_object($product),
-            ));
+            $products = self::hydrate($ids);
 
             if ($products !== []) {
                 return $products;
@@ -682,11 +670,14 @@ final class ProductMigrator extends AbstractMigrator
     /**
      * Hydrate exactly these product IDs, for a retry run.
      *
-     * The same wc_get_products() call fetchBatch() hydrates its ID page with,
-     * carrying the identical type and status filter — a product that has since
-     * been trashed, or whose type was changed to one this migrator does not
+     * A retry list comes out of a previous run's log, so unlike fetchBatch()'s
+     * ID page it has been through no filter at all — which is why it goes
+     * through migratableIdsAmong() first. That applies the same post_type,
+     * status trio and ProductTypes predicate the ID page applies, so a product
+     * since trashed, or whose type was changed to one this migrator does not
      * handle, is not returned rather than being migrated by a back door the
-     * normal run does not have.
+     * normal run does not have. What it deliberately does not apply is the
+     * scope predicate: a retry re-attempts records the owner already chose.
      *
      * The page cursor is left alone: a retry paginates an ID list, not wp_posts.
      *
@@ -703,27 +694,98 @@ final class ProductMigrator extends AbstractMigrator
             return [];
         }
 
-        $products = wc_get_products([
-            'limit'   => count($ids),
-            'include' => $ids,
-            'type'    => $this->getProductTypes(),
-            'status'  => ['publish', 'draft', 'private'],
-            'orderby' => 'ID',
-            'order'   => 'ASC',
-        ]);
+        return self::hydrate($this->migratableIdsAmong($ids));
+    }
 
-        return array_values(array_filter(
-            (array) $products,
-            static fn (mixed $product): bool => is_object($product),
+    /**
+     * Turn a settled list of product IDs into product objects.
+     *
+     * Not wc_get_products(). That call cannot express this list: WC_Product_Query
+     * always emits a `product_type` tax_query — an explicit `type` argument
+     * becomes one, and omitting `type` merely defaults it to every registered
+     * type and emits one anyway — so a product carrying no product_type term is
+     * unreachable through it, whatever arguments are passed. WooCommerce itself
+     * reads such a product as simple, this migrator's ID page now includes it,
+     * and hydrating through a taxonomy query would drop it again one step later:
+     * counted in the total, never handed to the orchestrator, never logged.
+     *
+     * So hydrate the way WooCommerce's own data store does once its WP_Query has
+     * run — prime the caches for the whole page in one pass, then wc_get_product()
+     * per ID — minus the taxonomy query this list does not need, because
+     * fetchProductIdPage() and migratableIdsAmong() have already applied it.
+     *
+     * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::query() (v11.0.0, line 2452)
+     * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::get_wp_query_args() (v11.0.0, line 2242)
+     *
+     * @param list<int> $ids
+     *
+     * @return list<\WC_Product>
+     */
+    private static function hydrate(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        if (function_exists('_prime_post_caches')) {
+            _prime_post_caches($ids);
+        }
+
+        $products = [];
+
+        foreach ($ids as $id) {
+            $product = wc_get_product($id);
+
+            if (is_object($product)) {
+                $products[] = $product;
+            }
+        }
+
+        return $products;
+    }
+
+    /**
+     * Which of these product IDs a run would actually source.
+     *
+     * The retry path's counterpart to fetchProductIdPage()'s WHERE clause,
+     * minus the keyset range and the scope. One predicate, one place.
+     *
+     * @param list<int> $ids
+     *
+     * @return list<int>
+     */
+    private function migratableIdsAmong(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        global $wpdb;
+
+        [$typeSql, $typeValues] = ProductTypes::migratableClause('p.ID');
+        $idHoles = implode(', ', array_fill(0, count($ids), '%d'));
+
+        $rows = $wpdb->get_col($wpdb->prepare(
+            "SELECT p.ID
+             FROM {$wpdb->posts} p
+             WHERE p.post_type = 'product'
+               AND p.post_status IN ('publish', 'draft', 'private')
+               AND p.ID IN ({$idHoles})
+               AND {$typeSql}
+             ORDER BY p.ID ASC",
+            ...[...$ids, ...$typeValues],
         ));
+
+        return array_values(array_map(intval(...), (array) $rows));
     }
 
     /**
      * The cursor is the end of the ID page, not the last hydrated record.
      *
-     * If wc_get_products() drops a trailing ID — a corrupt row, a filter that
-     * vetoes it — resuming from the last hydrated product would re-read that ID
-     * for ever. The page end always moves forward.
+     * If hydration drops a trailing ID — a corrupt row, a filter on
+     * woocommerce_product_class that vetoes it — resuming from the last
+     * hydrated product would re-read that ID for ever. The page end always
+     * moves forward.
      */
     #[\Override]
     public function cursorFor(mixed $record): string|int
@@ -744,8 +806,7 @@ final class ProductMigrator extends AbstractMigrator
     {
         global $wpdb;
 
-        $types = $this->getProductTypes();
-        $placeholders = implode(',', array_fill(0, count($types), '%s'));
+        [$typeSql, $typeValues] = ProductTypes::migratableClause('pml.product_id');
         $selection = $this->scopeResolver()->productPredicate('p.ID');
 
         $ids = $wpdb->get_col($wpdb->prepare(
@@ -755,17 +816,11 @@ final class ProductMigrator extends AbstractMigrator
              WHERE p.post_type = 'product'
                AND p.post_status IN ('publish', 'draft', 'private')
                AND p.ID > %d
-               AND pml.product_id IN (
-                   SELECT object_id FROM {$wpdb->term_relationships} tr
-                   INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-                   INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-                   WHERE tt.taxonomy = 'product_type'
-                     AND t.slug IN ({$placeholders})
-               )"
+               AND {$typeSql}"
             . $selection->andSql()
             . " ORDER BY p.ID ASC
              LIMIT %d",
-            ...[$afterId, ...$types, ...$selection->values(), $limit],
+            ...[$afterId, ...$typeValues, ...$selection->values(), $limit],
         ));
 
         return array_map(intval(...), $ids);
@@ -1305,24 +1360,6 @@ final class ProductMigrator extends AbstractMigrator
         }
 
         return $fallbackId;
-    }
-
-    /**
-     * FIX H10: include 'subscription' and 'variable-subscription' product types
-     * when WC Subscriptions is active.
-     *
-     * @return string[]
-     */
-    private function getProductTypes(): array
-    {
-        $types = ['simple', 'variable'];
-
-        if (class_exists('WC_Subscriptions')) {
-            $types[] = 'subscription';
-            $types[] = 'variable-subscription';
-        }
-
-        return $types;
     }
 
     /**

--- a/plugins/cartshift/app/Support/ProductTypes.php
+++ b/plugins/cartshift/app/Support/ProductTypes.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CartShift\Support;
+
+defined('ABSPATH') || exit;
+
+/**
+ * The one answer to "can CartShift migrate this product?".
+ *
+ * There used to be four, and they disagreed. PreflightCheck kept a constant,
+ * PreviewController and ScopeConsequences derived a negative slug list from it,
+ * and ProductMigrator kept a second copy of the list that was gated on
+ * WooCommerce Subscriptions being loaded — so on a store that had once sold
+ * subscriptions and then disabled the add-on, preflight and the picker called
+ * those products migratable while the migrator quietly dropped them. Three
+ * docblocks already said a second copy must never exist. Nothing enforced it.
+ * This class is the enforcement: one list, one SQL predicate, four callers.
+ *
+ * Two rules are load-bearing and neither is obvious.
+ *
+ * 1. A product with NO `product_type` term is a simple product. That is
+ *    WooCommerce's own reading, not a guess — the data store resolves a missing
+ *    term to ProductType::SIMPLE rather than to nothing, so the catalogue, the
+ *    admin product list and wc_get_product() all treat such a row as an
+ *    ordinary simple product. CartShift has to agree, which is why the
+ *    predicate is "has a supported-type term OR has no product_type term at
+ *    all" rather than a plain `IN (...)`. A plain `IN (...)` requires the term
+ *    row to exist and so drops the product without ever mentioning it: not in
+ *    the total, not in the log, not on any screen.
+ *
+ * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::get_product_type() (v11.0.0, line 2149)
+ *
+ * 2. The subscription types are conditional on WooCommerce Subscriptions being
+ *    loaded, and that condition belongs here rather than in one caller. See
+ *    supported() for why the gate is protective rather than merely defensive.
+ */
+final class ProductTypes
+{
+    /**
+     * Types CartShift can migrate whatever else is installed.
+     *
+     * `grouped` and `external` are absent deliberately: ProductMapper::map()
+     * returns null for both, so they are unmigratable at the mapping layer too
+     * and the two layers must not disagree about it.
+     *
+     * @var list<string>
+     */
+    private const array BASE_TYPES = ['simple', 'variable'];
+
+    /**
+     * Types CartShift can migrate only while WooCommerce Subscriptions is loaded.
+     *
+     * @var list<string>
+     */
+    private const array SUBSCRIPTION_TYPES = ['subscription', 'variable-subscription'];
+
+    /**
+     * The `product_type` term slugs a run on THIS site can migrate.
+     *
+     * The WooCommerce Subscriptions gate is real, not superstition. Nothing
+     * fatals without the add-on — wc_get_products(['type' => 'subscription'])
+     * is a slug-matched taxonomy query and answers perfectly well whether or
+     * not any subscription class is loaded — but what comes back is wrong in a
+     * way no log row would record:
+     *
+     *  - WC_Product_Factory falls back to WC_Product_Simple when the class for
+     *    a type does not exist, so a `subscription` product hydrates as a
+     *    simple one and get_type() answers 'simple'.
+     *  - VariationMapper only reads `_subscription_period` and friends behind
+     *    class_exists('WC_Subscriptions_Product'), so the recurring
+     *    configuration is dropped and the product arrives as a one-off sale.
+     *  - Worse for `variable-subscription`: WC_Product::get_children() on the
+     *    abstract returns an empty array, so every variation vanishes and the
+     *    product arrives with a single "Default" row priced off the parent.
+     *
+     * Migrating those silently is worse than not migrating them. So the types
+     * come off the supported list when the add-on is absent, which — because
+     * everything reads this one method — is also what preflight, the picker and
+     * the consequences panel then say out loud.
+     *
+     * @see woocommerce/includes/class-wc-product-factory.php::get_product_classname() (v11.0.0, line 78)
+     * @see woocommerce/includes/abstracts/abstract-wc-product.php::get_children() (v11.0.0, line 2012)
+     *
+     * @return list<string>
+     */
+    public static function supported(): array
+    {
+        if (!class_exists('WC_Subscriptions')) {
+            return self::BASE_TYPES;
+        }
+
+        return [...self::BASE_TYPES, ...self::SUBSCRIPTION_TYPES];
+    }
+
+    /**
+     * `<column> is a product CartShift would migrate`, plus its ordered values.
+     *
+     * The second branch is the whole point: `NOT IN (every product carrying any
+     * product_type term)` is how "this product has no type term at all" is
+     * spelled in SQL, and WooCommerce reads that state as `simple`. WooCommerce
+     * writes the same accommodation itself — get_wp_query_args() ORs the slug
+     * match with a `NOT EXISTS` on the taxonomy whenever variations are in
+     * scope — so this is its shape, not an invention.
+     *
+     * `NOT IN` is safe against the usual NULL trap here: term_relationships
+     * .object_id is `bigint(20) unsigned NOT NULL`, so the subquery cannot
+     * yield a NULL that would collapse the whole predicate to UNKNOWN.
+     *
+     * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::get_wp_query_args() (v11.0.0, line 2249)
+     *
+     * @return array{0: string, 1: list<string>}
+     */
+    public static function migratableClause(string $column): array
+    {
+        global $wpdb;
+
+        $column    = self::sanitizeColumn($column);
+        $supported = self::supported();
+        $holes     = implode(', ', array_fill(0, count($supported), '%s'));
+
+        $sql = "(
+                    {$column} IN (
+                        SELECT tr.object_id
+                          FROM {$wpdb->term_relationships} tr
+                    INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+                    INNER JOIN {$wpdb->terms} t ON t.term_id = tt.term_id
+                         WHERE tt.taxonomy = 'product_type'
+                           AND t.slug IN ({$holes})
+                    )
+                    OR {$column} NOT IN (
+                        SELECT tr.object_id
+                          FROM {$wpdb->term_relationships} tr
+                    INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+                         WHERE tt.taxonomy = 'product_type'
+                    )
+                )";
+
+        return [$sql, $supported];
+    }
+
+    /**
+     * The exact complement of migratableClause(), by construction rather than
+     * by a second list someone has to keep in step.
+     *
+     * Built as `NOT (...)` on purpose. Written independently — as `IN (the
+     * unsupported slugs present in this catalogue)`, which is what
+     * ScopeConsequences used to do — the two predicates disagree on any row the
+     * other one is silent about: a product with no type term counted as
+     * unmigratable under the positive form and as migratable under the negative
+     * one, which is precisely the divergence this class exists to end.
+     *
+     * @return array{0: string, 1: list<string>}
+     */
+    public static function unmigratableClause(string $column): array
+    {
+        [$sql, $values] = self::migratableClause($column);
+
+        return ['NOT ' . $sql, $values];
+    }
+
+    /**
+     * `SELECT object_id` for every product carrying a `product_type` term.
+     *
+     * Exposed so the one caller that needs the complement as a standalone
+     * subquery — counting products with no type term at all — does not write a
+     * third copy of the join.
+     */
+    public static function typedProductSubquery(): string
+    {
+        global $wpdb;
+
+        return "SELECT tr.object_id
+                  FROM {$wpdb->term_relationships} tr
+            INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+                 WHERE tt.taxonomy = 'product_type'";
+    }
+
+    /**
+     * The column this predicate is applied to, or `p.ID` if it is not one of
+     * the two shapes a caller is allowed to ask for.
+     *
+     * Allow-list, not strip-list. Stripping the characters that "look
+     * dangerous" is what lets `p.ID; DROP TABLE wp_posts; --` through as
+     * `p.ID DROP TABLE wp_posts` — still nonsense in the query, and nonsense
+     * the caller cannot see. Only two forms are ever wanted: a plain
+     * `table.column` and the `CAST(im.meta_value AS UNSIGNED)` that
+     * ScopeConsequences needs to compare a line-item meta value with a post ID.
+     * Anything else is a programming error, and falling back to a valid column
+     * keeps it a wrong answer rather than a broken query.
+     */
+    private static function sanitizeColumn(string $column): string
+    {
+        $column = trim($column);
+
+        $identifier = '[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?';
+
+        if (preg_match('/^' . $identifier . '$/', $column) === 1) {
+            return $column;
+        }
+
+        if (preg_match('/^CAST\(' . $identifier . ' AS [A-Za-z]+\)$/', $column) === 1) {
+            return $column;
+        }
+
+        return 'p.ID';
+    }
+}

--- a/plugins/cartshift/app/Validator/PreflightCheck.php
+++ b/plugins/cartshift/app/Validator/PreflightCheck.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CartShift\Validator;
 
+use CartShift\Support\ProductTypes;
 use CartShift\Support\WooStorage;
 
 defined('ABSPATH') || exit;
@@ -37,21 +38,6 @@ final class PreflightCheck
     private const string ORDER_UTIL = '\Automattic\WooCommerce\Utilities\OrderUtil';
 
     private const string HPOS_DATA_STORE = '\Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore';
-
-    /**
-     * WooCommerce product types CartShift can migrate.
-     *
-     * The single definition of "supported" — checkProductTypes() and
-     * ScopeConsequences::productLinkMissingCount() both read it, by way of
-     * unsupportedProductTypeCounts(), rather than each keeping their own copy.
-     * A preflight warning and a scope consequence count that disagreed about
-     * which types are unsupported would be quoted side by side to the same
-     * user; this project has produced three separate defects from exactly
-     * that class of drift.
-     *
-     * @var list<string>
-     */
-    private const array SUPPORTED_PRODUCT_TYPES = ['simple', 'variable', 'subscription', 'variable-subscription'];
 
     /**
      * WooCommerce plugins that grant entitlements (course access, membership levels)
@@ -391,10 +377,10 @@ final class PreflightCheck
     /**
      * ADVISORY. Never blocks.
      *
-     * Unsupported product types are excluded from getProductTypes(), which is what
-     * countTotal() and fetchBatch() filter on — by design, because CartShift cannot
-     * map, say, a LearnDash course product's data and attempting to would fail in
-     * worse and less visible ways than not migrating it at all.
+     * Unsupported product types are excluded by ProductTypes::migratableClause(),
+     * which is what countTotal() and fetchBatch() filter on — by design, because
+     * CartShift cannot map, say, a LearnDash course product's data and attempting
+     * to would fail in worse and less visible ways than not migrating it at all.
      *
      * The trap: excluded from the denominator means invisible, not skipped. A store
      * with 27 products where 2 are `course` reports "25 / 25 migrated" and never
@@ -473,10 +459,19 @@ final class PreflightCheck
     }
 
     /**
-     * Every product_type term present in the catalogue, keyed by slug, with how
-     * many products carry it. publish/draft/private only — the same trio
+     * The catalogue's product types, keyed by slug, with how many products
+     * carry each. publish/draft/private only — the same trio
      * countOrdersAffectedByTypes() restricts to, so a product sitting in the
      * trash cannot inflate either number.
+     *
+     * Products with no `product_type` term at all are counted under `simple`,
+     * because that is what they are: WooCommerce resolves a missing term to
+     * ProductType::SIMPLE, ProductTypes::migratableClause() therefore lets them
+     * through, and the migrator's total includes them. A histogram that left
+     * them out would report "Simple: 25" on a store the progress bar then takes
+     * to 26 — the same disagreement, one screen earlier.
+     *
+     * @see \CartShift\Support\ProductTypes
      *
      * @return array<string, int>
      */
@@ -502,7 +497,33 @@ final class PreflightCheck
             $types[$row->slug] = (int) $row->count;
         }
 
+        $untyped = self::untypedProductCount();
+
+        if ($untyped > 0) {
+            $types['simple'] = ($types['simple'] ?? 0) + $untyped;
+            arsort($types);
+        }
+
         return $types;
+    }
+
+    /**
+     * Products carrying no `product_type` term at all.
+     *
+     * Same status trio, same post_type, and the subquery comes from
+     * ProductTypes rather than being spelled out a fourth time.
+     */
+    private static function untypedProductCount(): int
+    {
+        global $wpdb;
+
+        return (int) $wpdb->get_var(
+            "SELECT COUNT(*)
+             FROM {$wpdb->posts} p
+             WHERE p.post_type = 'product'
+               AND p.post_status IN ('publish', 'draft', 'private')
+               AND p.ID NOT IN (" . ProductTypes::typedProductSubquery() . ')',
+        );
     }
 
     /**
@@ -513,7 +534,7 @@ final class PreflightCheck
     {
         $unsupported = [];
 
-        foreach (array_diff(array_keys($types), self::SUPPORTED_PRODUCT_TYPES) as $slug) {
+        foreach (array_diff(array_keys($types), ProductTypes::supported()) as $slug) {
             $unsupported[$slug] = $types[$slug];
         }
 
@@ -524,8 +545,12 @@ final class PreflightCheck
      * product_type slugs CartShift cannot migrate, each with how many products
      * in the catalogue carry it.
      *
-     * The one place that answers "which types are unsupported" — see
-     * SUPPORTED_PRODUCT_TYPES for why there must be only one.
+     * Catalogue-dependent, which is why it lives here rather than on
+     * ProductTypes: the answer is the difference between the terms this shop
+     * actually uses and ProductTypes::supported(). The supported side is never
+     * restated — see that class for why there must be only one of it, and note
+     * that on a store where WooCommerce Subscriptions has been disabled the
+     * subscription slugs appear here, deliberately.
      *
      * @return array<string, int>
      */

--- a/plugins/cartshift/tests/Unit/Http/Controllers/PreviewControllerTest.php
+++ b/plugins/cartshift/tests/Unit/Http/Controllers/PreviewControllerTest.php
@@ -10,6 +10,7 @@ use CartShift\Http\Controllers\PreviewController;
 use CartShift\State\MigrationState;
 use CartShift\Storage\IdMapRepository;
 use CartShift\Storage\MigrationLogRepository;
+use CartShift\Support\ProductTypes;
 use CartShift\Tests\Unit\PluginTestCase;
 use WP_REST_Request;
 
@@ -177,12 +178,11 @@ final class PreviewControllerTest extends PluginTestCase
      * the pick travels silently into MigrationScope::productIds() and only
      * evaporates later as counts['product'] === 0 with no explanation.
      *
-     * Simulates the NOT IN exclusion for real: the fake product_type_counts
+     * Simulates the type predicate for real: the fake product_type_counts
      * query reports one `course`-type product, and the fake results handler
-     * for the main product query parses the `t.slug IN (...)` values the
-     * code actually sent and drops matching fixture rows before returning
-     * them — so this fails if the exclusion clause is ever missing, not just
-     * if the fixture happens to agree with it.
+     * for the main product query evaluates the predicate the code actually
+     * sent against the fixture rows — so this fails if the predicate is ever
+     * missing, not just if the fixture happens to agree with it.
      */
     public function testUnsupportedProductTypeIsExcludedFromSearch(): void
     {
@@ -222,17 +222,59 @@ final class PreviewControllerTest extends PluginTestCase
     }
 
     /**
-     * No unsupported type present in the catalogue: the exclusion subquery
-     * must not be added at all, matching PreflightCheck's own "empty diff"
-     * shortcut and confirming this is not a permanent, unconditional clause.
+     * A product with no `product_type` term is an ordinary simple product —
+     * that is WooCommerce's own reading of a missing term — so the picker has
+     * to offer it, and the migrator has to migrate it. Both halves matter and
+     * they used to be answered differently: the picker's old `NOT IN
+     * (unsupported slugs)` let such a product through, ProductMigrator's
+     * positive `IN (supported slugs)` did not, and the owner picked something
+     * that then evaporated as counts['product'] === 0.
+     *
+     * `'type' => null` is the fixture's spelling of "no term row at all"; see
+     * stubProductTypeFixture(), which drops such a row unless the query really
+     * carries the no-type branch.
      */
-    public function testNoExclusionClauseWhenNothingIsUnsupported(): void
+    public function testAProductWithNoTypeTermIsStillOfferedByThePicker(): void
+    {
+        $this->stubProductTypeFixture(
+            rows: [
+                ['id' => 1, 'title' => 'Hoodie Untyped', 'sku' => '', 'type' => null],
+                ['id' => 2, 'title' => 'Hoodie Course', 'sku' => '', 'type' => 'course'],
+            ],
+            typeCounts: [['slug' => 'course', 'count' => 1]],
+        );
+
+        $labels = array_column(
+            $this->controller()->search($this->request(['type' => 'product', 'q' => 'hoodie']))
+                ->get_data()['data']['results'],
+            'label',
+        );
+
+        $this->assertContains('Hoodie Untyped', $labels);
+        $this->assertNotContains('Hoodie Course', $labels);
+    }
+
+    /**
+     * The predicate is unconditional now, and that is the fix rather than an
+     * oversight. It used to be added only when the catalogue happened to
+     * contain an unsupported type, which meant the picker asked a different
+     * question from the migrator on every store that had none — and the
+     * migrator's question, the one that decides what actually travels, is
+     * asked every time.
+     */
+    public function testTheTypePredicateIsAppliedEvenWithNothingUnsupportedInTheCatalogue(): void
     {
         $db = $this->stubSearchResults(productRows: [['id' => 1, 'title' => 'Hoodie', 'sku' => '']]);
 
         $this->controller()->search($this->request(['type' => 'product', 'q' => 'hoodie']));
 
-        $this->assertStringNotContainsString('NOT IN', $db->lastQuery);
+        [$expected, $values] = ProductTypes::migratableClause('p.ID');
+
+        $this->assertStringContainsString(
+            $GLOBALS['wpdb']->prepare($expected, ...$values),
+            $db->lastQuery,
+            'The picker must ask the migrator\'s question, not a lookalike.',
+        );
     }
 
     public function testSearchLimitIsClampedToFifty(): void
@@ -360,16 +402,23 @@ final class PreviewControllerTest extends PluginTestCase
      * see PreflightCheckTest) rather than a custom wpdb subclass, because this
      * one has to behave like a real database: the product_type_counts branch
      * reports the configured type histogram, and the main product query
-     * parses the `t.slug IN (...)` values PreviewController actually put in
-     * the query and filters `$rows` by them before returning — so a missing
-     * or wrong exclusion clause fails the test on its own, not on a fixture
-     * that was curated to already look filtered.
+     * evaluates the type predicate PreviewController actually put in the query
+     * against `$rows` before returning them — so a missing or wrong predicate
+     * fails the test on its own, not on a fixture that was curated to already
+     * look filtered.
+     *
+     * The predicate is positive now (ProductTypes::migratableClause: the slug
+     * list in `t.slug IN (...)` is what CartShift CAN migrate, not what it
+     * cannot) with a second branch for products carrying no `product_type`
+     * term at all. A fixture row spells that state as `'type' => null`, and
+     * this stub honours it exactly as the SQL does: kept, because WooCommerce
+     * reads a missing term as `simple`.
      *
      * Cleared automatically: tearDown() already unsets
      * _cartshift_test_get_results_callback after every test.
      *
-     * @param list<array{id: int, title: string, sku: string, type: string}> $rows
-     * @param list<array{slug: string, count: int}>                         $typeCounts
+     * @param list<array{id: int, title: string, sku: string, type: string|null}> $rows
+     * @param list<array{slug: string, count: int}>                               $typeCounts
      */
     private function stubProductTypeFixture(array $rows, array $typeCounts): void
     {
@@ -382,18 +431,24 @@ final class PreviewControllerTest extends PluginTestCase
                 return [];
             }
 
-            $excludedTypes = [];
+            $supportedTypes = [];
 
             if (preg_match('/t\.slug IN \(([^)]*)\)/', $query, $matches)) {
-                $excludedTypes = array_map(
+                $supportedTypes = array_map(
                     static fn (string $slug): string => trim($slug, " '"),
                     explode(',', $matches[1]),
                 );
             }
 
+            // The no-type branch of the real predicate. Without it in the
+            // query, an untyped fixture row must disappear here too.
+            $admitsUntyped = str_contains($query, "NOT IN (\n                        SELECT tr.object_id");
+
             return array_values(array_filter(
                 $rows,
-                static fn (array $row): bool => !in_array($row['type'], $excludedTypes, true),
+                static fn (array $row): bool => $row['type'] === null
+                    ? $admitsUntyped
+                    : in_array($row['type'], $supportedTypes, true),
             ));
         };
     }

--- a/plugins/cartshift/tests/Unit/Migrator/Entity/FetchByIdsTest.php
+++ b/plugins/cartshift/tests/Unit/Migrator/Entity/FetchByIdsTest.php
@@ -54,9 +54,7 @@ final class FetchByIdsTest extends PluginTestCase
 
     public function testProductFetchByIdsHydratesTheRequestedRecords(): void
     {
-        $GLOBALS['_cartshift_test_wc_product_batches'] = [
-            [(object) ['id' => 11], (object) ['id' => 12]],
-        ];
+        $this->stubMigratableProducts([11, 12]);
 
         $records = $this->productMigrator()->fetchByIds(['11', '12']);
 
@@ -65,33 +63,51 @@ final class FetchByIdsTest extends PluginTestCase
 
     public function testProductFetchByIdsShortCircuitsOnAnEmptyList(): void
     {
-        $GLOBALS['_cartshift_test_wc_product_batches'] = [
-            [(object) ['id' => 11]],
-        ];
+        $this->stubMigratableProducts([11]);
+        $GLOBALS['_cartshift_test_queries'] = [];
 
         $this->assertSame([], $this->productMigrator()->fetchByIds([]));
 
-        $this->assertCount(
-            1,
-            $GLOBALS['_cartshift_test_wc_product_batches'],
+        $this->assertSame(
+            [],
+            $GLOBALS['_cartshift_test_queries'],
             'An empty ID list must not cost a query.',
         );
     }
 
-    public function testProductFetchByIdsDropsNonObjectsTheQueryLayerHandsBack(): void
+    public function testProductFetchByIdsDropsIdsThatNoLongerHydrate(): void
     {
-        $GLOBALS['_cartshift_test_wc_product_batches'] = [
-            [(object) ['id' => 11], false, null, (object) ['id' => 13]],
-        ];
+        // The predicate admits all three; only two still have a post behind
+        // them. A corrupt row must not become a null in the batch.
+        $this->stubMigratableProducts([11, 12, 13]);
+        unset($GLOBALS['_cartshift_test_wc_products'][12]);
 
-        $this->assertCount(2, $this->productMigrator()->fetchByIds([11, 13]));
+        $this->assertCount(2, $this->productMigrator()->fetchByIds([11, 12, 13]));
+    }
+
+    /**
+     * A retry list comes out of a log, not out of a filtered query, so it is
+     * the one path where an unmigratable product could be handed straight to
+     * the mapper. It goes through the same ProductTypes predicate the normal
+     * run's ID page does — a `course` product whose earlier failure the owner
+     * is retrying stays out, whatever the log says.
+     */
+    public function testProductFetchByIdsAppliesTheSameTypePredicateAsANormalRun(): void
+    {
+        // The database answers for the predicate: 12 does not satisfy it.
+        $this->stubMigratableProducts([11, 12, 13], migratable: [11, 13]);
+
+        $records = $this->productMigrator()->fetchByIds([11, 12, 13]);
+
+        $this->assertSame([11, 13], array_map(static fn (object $p): int => $p->id, $records));
+
+        $predicateQuery = end($GLOBALS['_cartshift_test_queries']);
+        $this->assertStringContainsString("tt.taxonomy = 'product_type'", (string) ($predicateQuery[1] ?? ''));
     }
 
     public function testProductFetchByIdsLeavesTheKeysetCursorAlone(): void
     {
-        $GLOBALS['_cartshift_test_wc_product_batches'] = [
-            [(object) ['id' => 11]],
-        ];
+        $this->stubMigratableProducts([11]);
 
         $migrator = $this->productMigrator();
         $migrator->fetchByIds([11]);
@@ -102,6 +118,34 @@ final class FetchByIdsTest extends PluginTestCase
             $cursor->getValue($migrator),
             'A retry paginates an ID list; moving the keyset cursor would corrupt a normal run.',
         );
+    }
+
+    /**
+     * Seed a catalogue: `$ids` all have a product row to hydrate, and
+     * `$migratable` (defaulting to all of them) is what the type/status
+     * predicate answers with.
+     *
+     * @param list<int>      $ids
+     * @param list<int>|null $migratable
+     */
+    private function stubMigratableProducts(array $ids, ?array $migratable = null): void
+    {
+        $admitted = $migratable ?? $ids;
+
+        foreach ($ids as $id) {
+            $GLOBALS['_cartshift_test_wc_products'][$id] = (object) ['id' => $id];
+        }
+
+        $GLOBALS['_cartshift_test_get_col_callback'] = static function (string $query) use ($admitted): array {
+            if (!str_contains($query, "tt.taxonomy = 'product_type'")) {
+                return [];
+            }
+
+            return array_values(array_filter(
+                array_map(strval(...), $admitted),
+                static fn (string $id): bool => str_contains($query, $id),
+            ));
+        };
     }
 
     // ──────────────────────────────────────────────

--- a/plugins/cartshift/tests/Unit/Migrator/Entity/KeysetSourceQueryTest.php
+++ b/plugins/cartshift/tests/Unit/Migrator/Entity/KeysetSourceQueryTest.php
@@ -10,13 +10,11 @@ use CartShift\Migrator\SubscriptionMigrator;
 use CartShift\State\MigrationState;
 use CartShift\Storage\IdMapRepository;
 use CartShift\Storage\MigrationLogRepository;
+use CartShift\Support\ProductTypes;
 use CartShift\Tests\Unit\PluginTestCase;
 
 require_once dirname(__DIR__, 3) . '/stubs/EntityMigratorStubs.php';
 require_once dirname(__DIR__, 3) . '/stubs/ProductMigratorStubs.php';
-// wc_get_products() lives in HttpCliStubs despite the name — see the header
-// there. Its queue semantics are load-bearing for testTheProductCursorIsTheEndOfTheIdPage,
-// so require it rather than defining a second, stateless copy here.
 require_once dirname(__DIR__, 3) . '/stubs/HttpCliStubs.php';
 
 /**
@@ -127,7 +125,11 @@ final class KeysetSourceQueryTest extends PluginTestCase
         $this->assertStringContainsString('LIMIT 40', $db->lastQuery);
         $this->assertStringNotContainsString('OFFSET', $db->lastQuery);
         $this->assertStringContainsString("p.post_status IN ('publish', 'draft', 'private')", $db->lastQuery);
-        $this->assertStringContainsString("t.slug IN ('simple','variable')", $db->lastQuery);
+
+        // The type filter is ProductTypes' predicate, byte for byte, not a
+        // second list that happens to say the same thing today.
+        [$typeSql, $typeValues] = ProductTypes::migratableClause('pml.product_id');
+        $this->assertStringContainsString($db->prepare($typeSql, ...$typeValues), $db->lastQuery);
     }
 
     public function testTheProductCursorIsTheEndOfTheIdPage(): void
@@ -135,7 +137,7 @@ final class KeysetSourceQueryTest extends PluginTestCase
         // The ID page covers 11 and 12; hydration only yields 11. Resuming from
         // the last hydrated product would re-read 12 for ever.
         $this->recordingWpdb([11, 12]);
-        $GLOBALS['_cartshift_test_wc_product_batches'] = [[(object) ['id' => 11]]];
+        $GLOBALS['_cartshift_test_wc_products'] = [11 => (object) ['id' => 11]];
 
         $migrator = $this->productMigrator();
         $batch = $migrator->fetchBatch(null, 50);

--- a/plugins/cartshift/tests/Unit/Support/ProductTypePredicateAgreementTest.php
+++ b/plugins/cartshift/tests/Unit/Support/ProductTypePredicateAgreementTest.php
@@ -1,0 +1,529 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CartShift\Tests\Unit\Support;
+
+use CartShift\Core\Container;
+use CartShift\Domain\Scope\MigrationScope;
+use CartShift\Domain\Scope\ScopeConsequences;
+use CartShift\Domain\Scope\ScopeResolver;
+use CartShift\Http\Controllers\PreviewController;
+use CartShift\Migrator\ProductMigrator;
+use CartShift\State\MigrationState;
+use CartShift\Storage\IdMapRepository;
+use CartShift\Storage\MigrationLogRepository;
+use CartShift\Support\ProductTypes;
+use CartShift\Tests\Unit\PluginTestCase;
+use CartShift\Validator\PreflightCheck;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use WP_REST_Request;
+
+require_once dirname(__DIR__, 2) . '/stubs/EntityMigratorStubs.php';
+require_once dirname(__DIR__, 2) . '/stubs/ProductMigratorStubs.php';
+require_once dirname(__DIR__, 2) . '/stubs/HttpCliStubs.php';
+require_once dirname(__DIR__, 2) . '/stubs/PreflightStubs.php';
+
+/**
+ * Four places decide whether CartShift can migrate a product, and for a long
+ * time they decided differently:
+ *
+ *   PreflightCheck            a private constant listing four types
+ *   PreviewController         NOT IN (the unsupported slugs this shop uses)
+ *   ScopeConsequences         the same negative list, admittedly divergent
+ *   ProductMigrator           a second copy of the constant, gated on the
+ *                             WooCommerce Subscriptions class being loaded
+ *
+ * Two defects fell out of that. A product carrying no `product_type` term was
+ * offered by the picker, ignored by the consequences panel and then dropped by
+ * the migrator's positive `IN (...)` join — silently, because a product absent
+ * from the denominator is not a skip, it is an absence. And on a store that had
+ * once sold subscriptions and disabled the add-on, the terms stayed in the
+ * database, so preflight and the picker called those products migratable while
+ * the migrator dropped them.
+ *
+ * Three docblocks already said a second copy must never exist. That is the
+ * point of this file: intent in prose is not a test. Each case below drives the
+ * real callers and compares the predicate they actually emitted against
+ * ProductTypes' — reintroduce a private list anywhere and it fails there.
+ */
+final class ProductTypePredicateAgreementTest extends PluginTestCase
+{
+    private ?\wpdb $originalWpdb = null;
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        if ($this->originalWpdb !== null) {
+            $GLOBALS['wpdb'] = $this->originalWpdb;
+            $this->originalWpdb = null;
+        }
+
+        parent::tearDown();
+    }
+
+    // ──────────────────────────────────────────────
+    // One predicate, four callers
+    // ──────────────────────────────────────────────
+
+    public function testTheMigratorsTotalUsesThePredicateAndNoPrivateList(): void
+    {
+        $this->productMigrator()->count();
+
+        $this->assertQueriesContain(ProductTypes::migratableClause('pml.product_id'));
+    }
+
+    public function testTheMigratorsIdPageUsesThePredicateAndNoPrivateList(): void
+    {
+        $this->productMigrator()->fetchBatch(null, 50);
+
+        $this->assertQueriesContain(ProductTypes::migratableClause('pml.product_id'));
+    }
+
+    public function testThePickerUsesThePredicateAndNoPrivateList(): void
+    {
+        $this->previewController()->search($this->request(['type' => 'product', 'q' => 'hoodie']));
+
+        $this->assertQueriesContain(ProductTypes::migratableClause('p.ID'));
+    }
+
+    /**
+     * The consequences panel counts what will be left behind, so it needs the
+     * complement — and takes it as `NOT (the migrator's predicate)` rather than
+     * writing its own. Anything else and the two are only accidentally
+     * opposite, which is how a product with no type term came to be dropped by
+     * one and reported as fine by the other.
+     */
+    public function testTheConsequencesPanelUsesTheExactComplementOfThePredicate(): void
+    {
+        $this->withCatalogueTypes(['simple' => 23, 'course' => 2]);
+
+        (new ScopeConsequences(new ScopeResolver(MigrationScope::everything())))->all();
+
+        $this->assertQueriesContain(ProductTypes::unmigratableClause('p.ID'));
+        $this->assertQueriesContain(ProductTypes::unmigratableClause('CAST(im.meta_value AS UNSIGNED)'));
+    }
+
+    /**
+     * The same catalogue, asked by all four in one go: whatever the supported
+     * list happens to be, every caller has to be quoting the same one. This is
+     * the assertion a fifth caller with its own list would fail.
+     */
+    public function testAllFourCallersQuoteTheSameSupportedList(): void
+    {
+        $this->withCatalogueTypes(['simple' => 23, 'course' => 2]);
+
+        $this->productMigrator()->count();
+        $this->productMigrator()->fetchBatch(null, 50);
+        $this->previewController()->search($this->request(['type' => 'product', 'q' => 'hoodie']));
+        (new ScopeConsequences(new ScopeResolver(MigrationScope::everything())))->all();
+
+        $queries = $this->predicateQueries();
+
+        $this->assertGreaterThanOrEqual(4, count($queries), 'All four callers must have asked.');
+
+        $lists = [];
+
+        foreach ($queries as $query) {
+            preg_match_all("/t\.slug IN \(([^)]*)\)/", $query, $matches);
+
+            foreach ($matches[1] as $list) {
+                $lists[trim($list)] = true;
+            }
+        }
+
+        $expected = "'" . implode("', '", ProductTypes::supported()) . "'";
+
+        $this->assertSame(
+            [$expected],
+            array_keys($lists),
+            'Every product-type slug list any of the four callers emitted must be ProductTypes::supported().',
+        );
+    }
+
+    // ──────────────────────────────────────────────
+    // D1 — a product with no product_type term
+    // ──────────────────────────────────────────────
+
+    /**
+     * WooCommerce resolves a product with no `product_type` term to
+     * ProductType::SIMPLE — so it is an ordinary simple product, and every
+     * screen that has an opinion about it has to say so.
+     *
+     * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::get_product_type() (v11.0.0, line 2149)
+     */
+    public function testTheMigratorSourcesAProductWithNoTypeTerm(): void
+    {
+        $this->productMigrator()->count();
+        $this->productMigrator()->fetchBatch(null, 50);
+
+        $branch = $this->noTypeBranch('pml.product_id');
+
+        // Both, separately. The total and the batch disagreeing is worse than
+        // either being wrong: it is a progress bar that never reaches the end.
+        $this->assertStringContainsString($branch, $this->lastQueryMatching('SELECT COUNT(*)', 'pml'));
+        $this->assertStringContainsString($branch, $this->lastQueryMatching('SELECT p.ID', 'pml'));
+    }
+
+    /**
+     * Fixing the SQL alone would have moved the defect rather than removed it.
+     * wc_get_products() cannot return a product with no `product_type` term
+     * under any arguments — WC_Product_Query always emits a tax_query, and
+     * omitting `type` merely defaults it to every registered type — so an ID
+     * page that now includes such a product would have lost it again at
+     * hydration: counted in the total, never handed to the orchestrator.
+     *
+     * Hydration therefore filters nothing. One product per ID, because the ID
+     * page already decided.
+     *
+     * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::get_wp_query_args() (v11.0.0, line 2242)
+     */
+    public function testHydrationYieldsOneProductPerIdOnThePage(): void
+    {
+        $this->stubIdPage([11, 12]);
+
+        $GLOBALS['_cartshift_test_wc_products'] = [
+            11 => (object) ['id' => 11],
+            // No product_type term, so unreachable through wc_get_products().
+            12 => (object) ['id' => 12],
+        ];
+
+        $batch = $this->productMigrator()->fetchBatch(null, 50);
+
+        $this->assertSame([11, 12], array_map(static fn (object $p): int => $p->id, $batch));
+    }
+
+    public function testThePickerOffersAProductWithNoTypeTerm(): void
+    {
+        $this->previewController()->search($this->request(['type' => 'product', 'q' => 'hoodie']));
+
+        $this->assertStringContainsString(
+            $this->noTypeBranch('p.ID'),
+            $this->lastQueryMatching('wc_product_meta_lookup', 'post_title LIKE'),
+        );
+    }
+
+    /**
+     * And the panel must not call it a loss. The complement of "has a supported
+     * term OR has no term" excludes it by construction; the old hand-written
+     * `IN (unsupported slugs)` excluded it by accident, and the accident was the
+     * only thing keeping those two answers in step.
+     */
+    public function testTheConsequencesPanelDoesNotCallANoTypeProductALoss(): void
+    {
+        $this->withCatalogueTypes(['simple' => 23, 'course' => 2]);
+
+        (new ScopeConsequences(new ScopeResolver(MigrationScope::everything())))->all();
+
+        [$migratable, $values] = ProductTypes::migratableClause('p.ID');
+
+        $this->assertStringContainsString(
+            'NOT ' . $GLOBALS['wpdb']->prepare($migratable, ...$values),
+            $this->lastQueryMatching('SELECT COUNT(*)', 'FROM wp_posts p', 't.slug IN ('),
+            'The count of unmigratable products is the negation of the migrator\'s own predicate, so a '
+            . 'product with no type term — which the predicate admits — cannot appear in it.',
+        );
+    }
+
+    /**
+     * The preflight histogram is a count the owner reads immediately before the
+     * progress bar quotes another. Leaving untyped products out of it reports
+     * "Simple: 25" over a run the migrator takes to 26 — the same disagreement
+     * as the rest of this file, one screen earlier.
+     */
+    public function testPreflightCountsAnUntypedProductAsSimple(): void
+    {
+        $this->withCatalogueTypes(['simple' => 25, 'course' => 2], untyped: 1);
+
+        $check = (new PreflightCheck())->run()['checks']['product_types'];
+
+        $this->assertSame(26, $check['types']['simple'], 'The untyped product is a simple product.');
+        $this->assertSame(28, array_sum($check['types']));
+        $this->assertSame(['course' => 2], $check['unsupported'], 'It is not unsupported, merely untyped.');
+    }
+
+    // ──────────────────────────────────────────────
+    // D2 — the WooCommerce Subscriptions gate
+    // ──────────────────────────────────────────────
+
+    /**
+     * The gate used to live in ProductMigrator alone. Disabling the add-on
+     * leaves the `subscription` terms in the database, so preflight and the
+     * picker went on calling those products migratable while the migrator
+     * dropped them.
+     *
+     * The gate is protective and stays — see ProductTypes::supported() for what
+     * migrating a subscription product without the add-on actually produces —
+     * so the honest outcome is that all four now report those products as
+     * unmigratable on such a store. Which is what this asserts: the same
+     * catalogue, one verdict.
+     */
+    public function testSubscriptionProductsAreUnmigratableEverywhereWithoutTheAddon(): void
+    {
+        $this->assertFalse(class_exists('WC_Subscriptions'), 'Precondition: the shared process has no add-on.');
+
+        $this->withCatalogueTypes(['simple' => 9, 'subscription' => 4, 'variable-subscription' => 2]);
+
+        $this->assertSame(
+            ['subscription' => 4, 'variable-subscription' => 2],
+            PreflightCheck::unsupportedProductTypeCounts(),
+            'Preflight must name them, rather than leaving the migrator to drop them quietly.',
+        );
+
+        $this->productMigrator()->count();
+        $this->previewController()->search($this->request(['type' => 'product', 'q' => 'sub']));
+        (new ScopeConsequences(new ScopeResolver(MigrationScope::everything())))->all();
+
+        $queries = $this->predicateQueries();
+
+        $this->assertGreaterThanOrEqual(3, count($queries));
+
+        foreach ($queries as $query) {
+            $this->assertStringNotContainsString(
+                "'subscription'",
+                $query,
+                'No caller may offer, count or source a subscription product without the add-on.',
+            );
+        }
+
+        // And the panel says so out loud rather than leaving it to the
+        // migrator to drop them off-screen: the negated predicate is what the
+        // unmigratable-product count is built from.
+        $this->assertQueriesContain(ProductTypes::unmigratableClause('p.ID'));
+    }
+
+    /**
+     * The other side of the gate. With the add-on loaded the same catalogue is
+     * fully migratable, and — the part that used to be wrong — preflight stops
+     * calling the subscription types unsupported at the same moment the
+     * migrator starts sourcing them, because both read one method.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testSubscriptionProductsAreMigratableEverywhereWithTheAddon(): void
+    {
+        require_once dirname(__DIR__, 2) . '/stubs/WcSubscriptionsStub.php';
+
+        $this->withCatalogueTypes(['simple' => 9, 'subscription' => 4, 'variable-subscription' => 2]);
+
+        $this->assertSame([], PreflightCheck::unsupportedProductTypeCounts());
+
+        $this->productMigrator()->count();
+        $this->previewController()->search($this->request(['type' => 'product', 'q' => 'sub']));
+
+        $queries = $this->predicateQueries();
+
+        $this->assertGreaterThanOrEqual(2, count($queries));
+
+        foreach ($queries as $query) {
+            $this->assertStringContainsString("'subscription'", $query);
+            $this->assertStringContainsString("'variable-subscription'", $query);
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Harness
+    // ──────────────────────────────────────────────
+
+    /**
+     * Describe the catalogue: a `product_type` histogram, plus how many
+     * products carry no type term at all.
+     *
+     * @param array<string, int> $types
+     */
+    private function withCatalogueTypes(array $types, int $untyped = 0): void
+    {
+        $rows = [];
+
+        foreach ($types as $slug => $count) {
+            $rows[] = (object) ['slug' => $slug, 'count' => $count];
+        }
+
+        $GLOBALS['_cartshift_test_get_results_callback'] = static function (string $query) use ($rows): array {
+            if (str_contains($query, 'GROUP BY t.slug')) {
+                return $rows;
+            }
+
+            return [];
+        };
+
+        $GLOBALS['_cartshift_test_get_var_callback'] = static function (string $query) use ($untyped): string {
+            if (str_contains($query, 'SHOW TABLES LIKE')) {
+                return 'exists';
+            }
+
+            // The untyped count is the only COUNT(*) that reaches wp_posts
+            // through the "carries no product_type term" anti-join.
+            if (str_contains($query, 'FROM wp_posts p') && str_contains($query, 'NOT IN')) {
+                return (string) $untyped;
+            }
+
+            return '0';
+        };
+    }
+
+    /**
+     * Make fetchProductIdPage() answer with exactly these IDs, once.
+     *
+     * @param list<int> $ids
+     */
+    private function stubIdPage(array $ids): void
+    {
+        $remaining = $ids;
+
+        $GLOBALS['_cartshift_test_get_col_callback'] = static function (string $query) use (&$remaining): array {
+            if (!str_contains($query, "tt.taxonomy = 'product_type'")) {
+                return [];
+            }
+
+            $page = $remaining;
+            $remaining = [];
+
+            return array_map(strval(...), $page);
+        };
+    }
+
+    /** @return list<string> Every query string the stubs were handed. */
+    private function recordedQueries(): array
+    {
+        $queries = [];
+
+        foreach ($GLOBALS['_cartshift_test_queries'] ?? [] as $entry) {
+            if (($entry[0] ?? '') === 'prepare') {
+                continue;
+            }
+
+            $queries[] = (string) ($entry[1] ?? '');
+        }
+
+        return $queries;
+    }
+
+    /**
+     * The queries that carry ProductTypes' predicate — not merely any query
+     * mentioning a slug list, because PreflightCheck::countOrdersAffectedByTypes()
+     * legitimately quotes the UNsupported slugs while counting the orders that
+     * carry them.
+     *
+     * Identified by the no-type branch, taken from the real clause rather than
+     * matched against a pattern retyped here.
+     *
+     * @return list<string>
+     */
+    private function predicateQueries(): array
+    {
+        $markers = array_map(
+            $this->noTypeBranch(...),
+            ['p.ID', 'pml.product_id', 'CAST(im.meta_value AS UNSIGNED)'],
+        );
+
+        return array_values(array_filter(
+            $this->recordedQueries(),
+            static function (string $query) use ($markers): bool {
+                foreach ($markers as $marker) {
+                    if (str_contains($query, $marker)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            },
+        ));
+    }
+
+    /**
+     * `<column> NOT IN (every product carrying any product_type term)` — the
+     * branch that makes an untyped product migratable, lifted straight out of
+     * ProductTypes so no test here re-types its SQL.
+     */
+    private function noTypeBranch(string $column): string
+    {
+        [$sql] = ProductTypes::migratableClause($column);
+
+        $parts = explode('OR ', $sql, 2);
+
+        $this->assertCount(2, $parts, 'migratableClause() must still have a no-type branch to find.');
+
+        return rtrim(rtrim(trim($parts[1]), ')'));
+    }
+
+    /**
+     * The last recorded query containing every one of these needles.
+     */
+    private function lastQueryMatching(string ...$needles): string
+    {
+        $matches = array_values(array_filter(
+            $this->recordedQueries(),
+            static function (string $query) use ($needles): bool {
+                foreach ($needles as $needle) {
+                    if (!str_contains($query, $needle)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            },
+        ));
+
+        $this->assertNotSame([], $matches, sprintf('No query matching "%s" was run.', implode('" + "', $needles)));
+
+        return (string) end($matches);
+    }
+
+    /**
+     * @param array{0: string, 1: list<string>} $clause
+     */
+    private function assertQueriesContain(array $clause): void
+    {
+        [$sql, $values] = $clause;
+
+        $expected = $GLOBALS['wpdb']->prepare($sql, ...$values);
+
+        foreach ($this->recordedQueries() as $query) {
+            if (str_contains($query, $expected)) {
+                $this->addToAssertionCount(1);
+
+                return;
+            }
+        }
+
+        $this->fail('No query carried ProductTypes\' predicate: ' . $expected);
+    }
+
+    private function productMigrator(): ProductMigrator
+    {
+        return new ProductMigrator(
+            new IdMapRepository(),
+            new MigrationLogRepository(),
+            new MigrationState(),
+        );
+    }
+
+    private function previewController(): PreviewController
+    {
+        $container = new Container();
+        $container->singleton(IdMapRepository::class, static fn (): IdMapRepository => new IdMapRepository());
+        $container->singleton(
+            MigrationLogRepository::class,
+            static fn (): MigrationLogRepository => new MigrationLogRepository(),
+        );
+        $container->singleton(MigrationState::class, static fn (): MigrationState => new MigrationState());
+
+        return new PreviewController($container);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function request(array $params): WP_REST_Request
+    {
+        $request = new WP_REST_Request();
+
+        foreach ($params as $key => $value) {
+            $request->set_param($key, $value);
+        }
+
+        return $request;
+    }
+}

--- a/plugins/cartshift/tests/Unit/Support/ProductTypesTest.php
+++ b/plugins/cartshift/tests/Unit/Support/ProductTypesTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CartShift\Tests\Unit\Support;
+
+use CartShift\Support\ProductTypes;
+use CartShift\Tests\Unit\PluginTestCase;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+/**
+ * The single definition of "can CartShift migrate this product?".
+ *
+ * There were four, and they disagreed on two separate axes — products with no
+ * `product_type` term, and subscription types on a store without the add-on.
+ * ProductTypePredicateAgreementTest pins that the four callers all read this
+ * class; these tests pin what it says.
+ */
+final class ProductTypesTest extends PluginTestCase
+{
+    public function testTheSubscriptionTypesAreAbsentWithoutTheAddon(): void
+    {
+        $this->assertFalse(class_exists('WC_Subscriptions'), 'Precondition for this test file.');
+
+        $this->assertSame(['simple', 'variable'], ProductTypes::supported());
+    }
+
+    /**
+     * The other side of the gate, and the reason it is a gate rather than a
+     * constant: with the add-on loaded the subscription types are migratable,
+     * and every caller picks that up from the same method on the same call.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testTheSubscriptionTypesArrivedWithTheAddon(): void
+    {
+        require_once dirname(__DIR__, 2) . '/stubs/WcSubscriptionsStub.php';
+
+        $this->assertSame(
+            ['simple', 'variable', 'subscription', 'variable-subscription'],
+            ProductTypes::supported(),
+        );
+    }
+
+    /**
+     * `grouped` and `external` are unmigratable at BOTH layers or the layers
+     * disagree: ProductMapper::map() returns null for them, and a predicate
+     * that admitted them would source a product the mapper then refuses, which
+     * is a log row where there should have been no record at all.
+     */
+    public function testTheTypesTheMapperRefusesAreNeverSupported(): void
+    {
+        $supported = ProductTypes::supported();
+
+        $this->assertNotContains('grouped', $supported);
+        $this->assertNotContains('external', $supported);
+    }
+
+    /**
+     * The heart of it. A plain `IN (supported slugs)` needs the term row to
+     * exist; WooCommerce reads a missing `product_type` term as simple, so the
+     * predicate has to carry a second branch for products that have no term at
+     * all. Without it a perfectly ordinary product is dropped from the total,
+     * from the batch and from the log at once.
+     *
+     * @see woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php::get_product_type() (v11.0.0, line 2149)
+     */
+    public function testTheClauseAdmitsProductsWithNoTypeTermAtAll(): void
+    {
+        [$sql, $values] = ProductTypes::migratableClause('p.ID');
+
+        $this->assertStringContainsString("t.slug IN (%s, %s)", $sql, 'The positive branch.');
+        $this->assertMatchesRegularExpression(
+            '/OR\s+p\.ID NOT IN \(\s*SELECT tr\.object_id/',
+            $sql,
+            'The no-type branch: "carries no product_type term at all" is spelled NOT IN, and its absence '
+            . 'is exactly the defect this predicate exists to fix.',
+        );
+        $this->assertSame(ProductTypes::supported(), $values);
+    }
+
+    /**
+     * The no-type branch must not be narrowed to the supported slugs. `NOT IN
+     * (products whose type is supported)` and `NOT IN (products with any type
+     * term)` differ on precisely the rows that matter: the second is "untyped",
+     * the first would re-admit every `course` product in the shop.
+     */
+    public function testTheNoTypeBranchIgnoresSlugsEntirely(): void
+    {
+        [$sql] = ProductTypes::migratableClause('p.ID');
+
+        $branches = explode('OR', $sql);
+
+        $this->assertCount(2, $branches);
+        $this->assertStringNotContainsString('t.slug', $branches[1]);
+        $this->assertStringNotContainsString('wp_terms', $branches[1]);
+    }
+
+    /**
+     * Complement by construction, not by a parallel list. Written
+     * independently the two drift, and every row one of them is silent about
+     * becomes a row the preview and the migrator disagree on.
+     */
+    public function testTheUnmigratableClauseIsTheExactNegationOfTheMigratableOne(): void
+    {
+        [$migratable, $migratableValues] = ProductTypes::migratableClause('p.ID');
+        [$unmigratable, $unmigratableValues] = ProductTypes::unmigratableClause('p.ID');
+
+        $this->assertSame('NOT ' . $migratable, $unmigratable);
+        $this->assertSame($migratableValues, $unmigratableValues);
+    }
+
+    public function testTheClauseIsBuiltForWhicheverColumnTheCallerJoinsOn(): void
+    {
+        [$sql] = ProductTypes::migratableClause('pml.product_id');
+
+        $this->assertStringContainsString('pml.product_id IN (', $sql);
+        $this->assertStringContainsString('pml.product_id NOT IN (', $sql);
+        $this->assertStringNotContainsString('p.ID', $sql);
+    }
+
+    /**
+     * ScopeConsequences applies the predicate to a line-item meta value, which
+     * has to be cast before it can be compared to a post ID. The parentheses
+     * and spaces of that expression must survive sanitising.
+     */
+    public function testACastExpressionSurvivesAsAColumn(): void
+    {
+        [$sql] = ProductTypes::migratableClause('CAST(im.meta_value AS UNSIGNED)');
+
+        $this->assertStringContainsString('CAST(im.meta_value AS UNSIGNED) IN (', $sql);
+        $this->assertStringContainsString('CAST(im.meta_value AS UNSIGNED) NOT IN (', $sql);
+    }
+
+    /**
+     * A column is never user input here, so this is about a programming error
+     * staying legible rather than about injection. Stripping "dangerous"
+     * characters would have turned this into `p.ID DROP TABLE wp_posts` — still
+     * broken, and broken somewhere the caller cannot see.
+     */
+    public function testAnUnusableColumnFallsBackRatherThanEmittingBrokenSql(): void
+    {
+        [$sql] = ProductTypes::migratableClause('p.ID; DROP TABLE wp_posts; --');
+
+        $this->assertStringNotContainsString('DROP', $sql);
+        $this->assertStringNotContainsString(';', $sql);
+        $this->assertStringContainsString('p.ID IN (', $sql);
+    }
+
+    public function testTheTypedProductSubqueryNamesOnlyTheProductTypeTaxonomy(): void
+    {
+        $subquery = ProductTypes::typedProductSubquery();
+
+        $this->assertStringContainsString('SELECT tr.object_id', $subquery);
+        $this->assertStringContainsString("tt.taxonomy = 'product_type'", $subquery);
+        $this->assertStringNotContainsString('product_cat', $subquery);
+    }
+}

--- a/plugins/cartshift/tests/stubs/WcSubscriptionsStub.php
+++ b/plugins/cartshift/tests/stubs/WcSubscriptionsStub.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The bare existence of WooCommerce Subscriptions.
+ *
+ * ProductTypes::supported() gates the two subscription product types on
+ * class_exists('WC_Subscriptions') and nothing else, so this empty shell is the
+ * whole of what a test needs to describe a store that has the add-on.
+ *
+ * NEVER require this file from a test that is not process-isolated. A class,
+ * once declared, cannot be undeclared, so loading it in the shared process
+ * would silently move every later test in the run onto the four-type list —
+ * including the several that assert the two-type one. Isolated callers must
+ * carry BOTH #[RunInSeparateProcess] and #[PreserveGlobalState(false)]; the
+ * first alone re-serialises the parent's declared classes into the child.
+ */
+
+if (!class_exists('WC_Subscriptions')) {
+    class WC_Subscriptions
+    {
+    }
+}


### PR DESCRIPTION
Four places decided "can CartShift migrate this product type", and they disagreed. `PreflightCheck` held the list, the picker and the consequences panel matched it **negatively** (`NOT IN (unsupported)`), and `ProductMigrator` kept a **second, environment-gated copy** and matched **positively**. The docblocks already said a second copy must never exist; nothing enforced it.

Now: `app/Support/ProductTypes.php` owns the list, the environment gate, `migratableClause()`, and `unmigratableClause()` = `NOT (migratable)`. `SUPPORTED_PRODUCT_TYPES` and `ProductMigrator::getProductTypes()` are gone.

## The untyped product — checked against WooCommerce, not against the migrator

WooCommerce resolves a product with **no `product_type` term** to `ProductType::SIMPLE` (`class-wc-product-data-store-cpt.php:2149`). It is an ordinary simple product.

CartShift dropped it: the migrator required a term row, the picker offered it, the consequences panel never reported it as a loss. Migrating "everything" quietly left it behind.

So the fix matches WooCommerce rather than matching the migrator — the predicate is *has a supported-type term **or** has no `product_type` term at all*. Unifying positively, as first proposed, would have made CartShift refuse products WooCommerce treats as perfectly normal.

**And the SQL alone would not have been enough.** `WC_Product_Query::get_default_query_vars()` defaults `type` to every registered type (`class-wc-product-query.php:31`), and the data store *always* appends a `product_type` tax_query from it (`:2241`). Omitting `type` does not help: an untyped product is unreachable through `wc_get_products()` under any arguments. Fixing only the ID query would have moved the loss one step later and made it harder to see — the ID page includes it, hydration drops it, the cursor advances, `countTotal()` counted it, and nothing is logged. Hydration now primes the caches and calls `wc_get_product()` per ID, which is what WooCommerce's own data store does at `:2452` once its `WP_Query` has run.

## The environment gate is protective, so it stays

`wc_get_products(['type' => 'subscription'])` runs fine without WooCommerce Subscriptions — it is a slug-matched taxonomy query and consults no class. But the factory falls back to `WC_Product_Simple`, `VariationMapper`'s recurring config is gated behind `class_exists('WC_Subscriptions_Product')`, and `WC_Product::get_children()` on the abstract returns `array()`, so a `variable-subscription` arrives as a single "Default" row with every variation gone. Nothing fatals; everything is quietly wrong — which is the failure this release exists to eliminate.

So the gate moves into the single definition, and all four sites now report those products as **unmigratable** on a store where WCS is inactive. That is the honest answer rather than the convenient one.

## Verification

**730 PHPUnit / 2342 assertions** (from 706), zero Risky, zero deprecations/notices/warnings. **233 vitest.** Both re-run independently, not taken from the report.

Nine mutations, each reverted after: no-type branch removed (10 failures), hydration back through `wc_get_products` (5), WCS gate removed (3), gate forced shut (2), migrator private list (3), consequences parallel list (4), histogram folding removed (1), retry bypasses predicate (1), picker drops predicate (7). The both-sides WCS tests use `#[RunInSeparateProcess]` with `#[PreserveGlobalState(false)]`.

A 529-line agreement test pins all four callers against each other, which is the only thing that stops this drifting apart again.

No migration was run, real or dry; the lapka store was untouched.

## Flagged, not fixed

**The committed admin bundle is stale on `main`** — a clean checkout rebuilds to a different hash with no source change. Unrelated to this work, but the shipped ZIP is built from `dist/`, so it deserves its own look.

**One extra COUNT per histogram read.** The untyped count is an anti-join and `ScopeConsequences::all()` reads the histogram up to four times per preview. Roughly doubles an existing cost rather than adding a new kind. The cheaper `total − array_sum(histogram)` is correct only while no product carries two `product_type` terms — true in practice, not by construction — so the exact form was kept.

**`_prime_post_caches()` is `@access private`** in core. Guarded with `function_exists`; WooCommerce itself calls it.