### PR TITLE
cartshift: one allow-list for column names, three callers

### DIFF
--- a/plugins/cartshift/app/Domain/Scope/ScopePredicate.php
+++ b/plugins/cartshift/app/Domain/Scope/ScopePredicate.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CartShift\Domain\Scope;
 
+use CartShift\Support\SqlIdentifier;
+
 defined('ABSPATH') || exit;
 
 /**
@@ -182,14 +184,12 @@ final class ScopePredicate
     }
 
     /**
-     * Column names are never user input here, but strip anything that is not a
-     * plausible identifier before it reaches a query string. Same guard
-     * WooStorage applies, and for the same reason.
+     * Column names are never user input here; SqlIdentifier keeps that true by
+     * construction rather than by everyone remembering. See its docblock for
+     * why an allow-list beats the strip-list this used to be.
      */
     private static function sanitizeIdentifier(string $identifier): string
     {
-        $clean = preg_replace('/[^A-Za-z0-9_.]/', '', $identifier) ?? '';
-
-        return $clean === '' ? 'id' : $clean;
+        return SqlIdentifier::column($identifier, 'id');
     }
 }

--- a/plugins/cartshift/app/Support/ProductTypes.php
+++ b/plugins/cartshift/app/Support/ProductTypes.php
@@ -192,18 +192,6 @@ final class ProductTypes
      */
     private static function sanitizeColumn(string $column): string
     {
-        $column = trim($column);
-
-        $identifier = '[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?';
-
-        if (preg_match('/^' . $identifier . '$/', $column) === 1) {
-            return $column;
-        }
-
-        if (preg_match('/^CAST\(' . $identifier . ' AS [A-Za-z]+\)$/', $column) === 1) {
-            return $column;
-        }
-
-        return 'p.ID';
+        return SqlIdentifier::column($column, 'p.ID');
     }
 }

--- a/plugins/cartshift/app/Support/SqlIdentifier.php
+++ b/plugins/cartshift/app/Support/SqlIdentifier.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace CartShift\Support;
+
+/**
+ * The one place that decides whether a string may be spliced into SQL as a
+ * column reference.
+ *
+ * There were three: WooStorage, ScopePredicate and ProductTypes each carried
+ * their own, and two of the three were strip-lists — delete every character
+ * outside `[A-Za-z0-9_.]` and use whatever survives. That is the weaker shape,
+ * for a reason worth stating plainly: stripping turns
+ * `o.status; DROP TABLE wp_posts` into `o.statusDROPTABLEwp_posts`, which is
+ * not an injection but is not a column either. The query fails at the database
+ * with an error naming a column nobody wrote, and the caller's actual mistake —
+ * passing something that was never an identifier — is now invisible.
+ *
+ * An allow-list answers the question that was actually being asked. Either the
+ * string has the shape of a column reference or it does not, and if it does not
+ * the caller gets a valid column instead of a broken query. That keeps a
+ * programming error a wrong answer rather than a fatal one, which matters here:
+ * these clauses run inside a migration, and a migration that dies mid-run costs
+ * an owner more than one that reports the wrong count.
+ *
+ * No user input reaches this today — every column in the codebase is a literal,
+ * and the only parameterised one is productPredicate()'s, which every caller
+ * passes 'p.ID'. This exists so that stays true by construction rather than by
+ * everyone remembering.
+ */
+final class SqlIdentifier
+{
+    /**
+     * A bare identifier, or a qualified one: `status`, `o.status`, `p.ID`.
+     *
+     * Deliberately does not permit a leading digit, because SQL does not.
+     */
+    private const string IDENTIFIER = '[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?';
+
+    /**
+     * `$column` if it is a column reference, `$fallback` if it is not.
+     *
+     * `CAST(<identifier> AS <TYPE>)` is allowed because ScopeConsequences needs
+     * it to compare a line-item meta value against a post ID, and wrapping that
+     * in a second helper would put us back at two implementations.
+     *
+     * `$fallback` is validated too. A caller that supplies a broken fallback
+     * has made the same mistake one level up, and silently trusting it would
+     * reintroduce exactly the hole this closes.
+     */
+    public static function column(string $column, string $fallback = 'p.ID'): string
+    {
+        if (self::isColumn($column)) {
+            return trim($column);
+        }
+
+        return self::isColumn($fallback) ? trim($fallback) : 'p.ID';
+    }
+
+    private static function isColumn(string $candidate): bool
+    {
+        $candidate = trim($candidate);
+
+        if (preg_match('/^' . self::IDENTIFIER . '$/', $candidate) === 1) {
+            return true;
+        }
+
+        return preg_match('/^CAST\(' . self::IDENTIFIER . ' AS [A-Za-z]+\)$/', $candidate) === 1;
+    }
+}

--- a/plugins/cartshift/app/Support/WooStorage.php
+++ b/plugins/cartshift/app/Support/WooStorage.php
@@ -303,13 +303,12 @@ final class WooStorage
     }
 
     /**
-     * Column names are never user input here, but strip anything that is not a
-     * plausible identifier before it reaches a query string.
+     * Column names are never user input here; SqlIdentifier keeps that true by
+     * construction rather than by everyone remembering. See its docblock for
+     * why an allow-list beats the strip-list this used to be.
      */
     private static function sanitizeIdentifier(string $identifier): string
     {
-        $clean = preg_replace('/[^A-Za-z0-9_.]/', '', $identifier) ?? '';
-
-        return $clean === '' ? 'status' : $clean;
+        return SqlIdentifier::column($identifier, 'status');
     }
 }

--- a/plugins/cartshift/tests/Unit/Migrator/Entity/WooStorageTest.php
+++ b/plugins/cartshift/tests/Unit/Migrator/Entity/WooStorageTest.php
@@ -138,10 +138,23 @@ final class WooStorageTest extends PluginTestCase
     {
         $clause = WooStorage::statusInClause(['wc-pending'], 'o.status; DROP TABLE wp_posts');
 
-        // Everything outside [A-Za-z0-9_.] is stripped, so the statement
-        // separator and the spaces that would make this a second query are gone.
+        // This used to assert `o.statusDROPTABLEwp_posts`, the strip-list's
+        // output: not an injection, but not a column either, so the query died
+        // at the database naming something nobody wrote. The allow-list asks
+        // the question that was actually being asked — is this a column
+        // reference? — and answers no, falling back to a valid one.
         $this->assertStringNotContainsString(';', $clause);
-        $this->assertSame("o.statusDROPTABLEwp_posts IN ('wc-pending')", $clause);
+        $this->assertStringNotContainsString('DROP', $clause);
+        $this->assertSame("status IN ('wc-pending')", $clause);
+    }
+
+    public function testStatusInClauseKeepsAQualifiedColumn(): void
+    {
+        // The fallback must not swallow the legitimate case it exists to guard.
+        $this->assertSame(
+            "o.status IN ('wc-pending')",
+            WooStorage::statusInClause(['wc-pending'], 'o.status'),
+        );
     }
 
     public function testOrderScopeClauseCombinesTypeAndStatus(): void

--- a/plugins/cartshift/tests/Unit/Support/SqlIdentifierTest.php
+++ b/plugins/cartshift/tests/Unit/Support/SqlIdentifierTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace CartShift\Tests\Unit\Support;
+
+use CartShift\Support\SqlIdentifier;
+use CartShift\Tests\Unit\PluginTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The three sanitisers this replaced were two strip-lists and an allow-list.
+ * These tests pin the allow-list's actual contract, in both directions: what it
+ * lets through unchanged, and what it refuses. A guard that only ever gets
+ * tested with hostile input tends to quietly reject legitimate input too.
+ */
+final class SqlIdentifierTest extends PluginTestCase
+{
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function columnReferences(): array
+    {
+        return [
+            ['status'],
+            ['o.status'],
+            ['p.ID'],
+            ['customer_id'],
+            ['billing_email'],
+            ['_id'],
+            ['t2.column_9'],
+            ['CAST(im.meta_value AS UNSIGNED)'],
+        ];
+    }
+
+    #[DataProvider('columnReferences')]
+    public function testAColumnReferencePassesThroughUnchanged(string $column): void
+    {
+        $this->assertSame($column, SqlIdentifier::column($column, 'p.ID'));
+    }
+
+    /**
+     * @return list<array{0: string, 1: string}>
+     */
+    public static function refusals(): array
+    {
+        return [
+            'statement separator'    => ['o.status; DROP TABLE wp_posts', 'a second statement'],
+            'comment'                => ['status -- x', 'a trailing comment'],
+            'space'                  => ['o status', 'two tokens rather than one'],
+            'leading digit'          => ['1status', 'not a legal identifier'],
+            'empty'                  => ['', 'nothing at all'],
+            'whitespace only'        => ['   ', 'nothing at all'],
+            'bare dot'               => ['.', 'no name either side'],
+            'trailing dot'           => ['o.', 'a qualifier with no column'],
+            'three parts'            => ['a.b.c', 'deeper than table.column'],
+            'quoted'                 => ['`status`', 'backticks are not part of the name'],
+            'function call'          => ['COUNT(status)', 'only CAST is permitted'],
+            'cast with a subquery'   => ['CAST((SELECT 1) AS UNSIGNED)', 'not an identifier inside'],
+        ];
+    }
+
+    #[DataProvider('refusals')]
+    public function testAnythingElseFallsBackToTheGivenColumn(string $column, string $why): void
+    {
+        $this->assertSame('p.ID', SqlIdentifier::column($column, 'p.ID'), $why);
+    }
+
+    public function testTheFallbackIsValidatedToo(): void
+    {
+        // A caller with a broken fallback has made the same mistake one level
+        // up. Trusting it would reintroduce exactly the hole this closes.
+        $this->assertSame(
+            'p.ID',
+            SqlIdentifier::column('nonsense; DROP TABLE wp_posts', 'also; nonsense'),
+        );
+    }
+
+    public function testSurroundingWhitespaceIsNotAReasonToRefuse(): void
+    {
+        $this->assertSame('o.status', SqlIdentifier::column('  o.status  ', 'p.ID'));
+    }
+}


### PR DESCRIPTION
`WooStorage` and `ScopePredicate` each carried a strip-list — delete every character outside `[A-Za-z0-9_.]`, use whatever survives. `ProductTypes`, written days later, used an allow-list and explained in its own docblock why the strip-list is the weaker shape.

Three copies of the same decision, two of them the version the third argued against.

## The argument is right

Stripping turns `o.status; DROP TABLE wp_posts` into `o.statusDROPTABLEwp_posts`. Not an injection — but not a column either. The query dies at the database naming something nobody wrote, and the caller's actual mistake, passing something that was never an identifier, is invisible.

The allow-list asks the question that was actually being asked — *is this a column reference?* — and when the answer is no, returns one that is. A programming error stays a wrong answer rather than becoming a fatal one, which matters inside a migration: a run that dies halfway costs an owner more than one that reports the wrong count.

The old test asserted the strip-list's output verbatim. It now asserts the fallback, with a comment explaining what changed and why.

## Verified, not assumed — the premise deserved checking

**No user input reaches any of the three today.** Every column in the codebase is a literal. The only parameterised one is `productPredicate()`'s `$column`, and all five call sites pass `'p.ID'`. `WooStorage::statusInClause` has **no production caller at all** — tests only.

So this is hardening and de-duplication, not a live hole. `SqlIdentifier` exists so that stays true by construction rather than by everyone remembering.

The fallback is validated too: a caller supplying a broken fallback has made the same mistake one level up, and trusting it would reintroduce exactly what this closes.

## Evidence

**753 tests** (from 730), 2366 assertions, zero Risky, zero deprecations/notices/warnings. 233 vitest.

Three mutations, each reverted after:

| Mutation | Failures |
|---|---|
| Back to the strip-list | **15** |
| Trust the fallback unvalidated | 1 |
| Permit a leading digit | 1 |

The refusal cases are a data provider covering statement separators, comments, embedded spaces, backtick quoting, three-part names, a bare dot, and a `CAST` wrapping a subquery. There is a matching pass-through set for `status`, `o.status`, `p.ID`, `CAST(im.meta_value AS UNSIGNED)` and friends — because a guard tested only with hostile input tends to quietly reject legitimate input too.

## Noted while verifying, not fixed here

`WooStorage::statusInClause()` is unreachable from `app/`. Either it is a public helper waiting for a caller or it is dead code; that is a judgement about intent rather than something to delete in a hardening PR.