### PR TITLE
cartshift: remove WooStorage::statusInClause, which nothing calls

### DIFF
--- a/plugins/cartshift/app/Support/WooStorage.php
+++ b/plugins/cartshift/app/Support/WooStorage.php
@@ -181,32 +181,6 @@ final class WooStorage
         return 'wc-' . $status;
     }
 
-    /**
-     * Build a prepared `<column> IN (...)` fragment.
-     *
-     * Every value goes through $wpdb->prepare. An empty status list yields a
-     * clause that matches nothing rather than one that matches everything —
-     * silently widening a filter is how abandoned carts got imported in the
-     * first place.
-     *
-     * @param list<string> $statuses
-     */
-    public static function statusInClause(array $statuses, string $column = 'status'): string
-    {
-        global $wpdb;
-
-        $statuses = self::normalizeStatuses($statuses);
-        $column   = self::sanitizeIdentifier($column);
-
-        if ($statuses === []) {
-            return '1 = 0';
-        }
-
-        return (string) $wpdb->prepare(
-            $column . ' IN (' . self::placeholders(count($statuses)) . ')',
-            ...$statuses,
-        );
-    }
 
     /**
      * Unprepared `type = %s AND status IN (%s, ...)` fragment plus its ordered
@@ -302,13 +276,4 @@ final class WooStorage
         return implode(', ', array_fill(0, $count, '%s'));
     }
 
-    /**
-     * Column names are never user input here; SqlIdentifier keeps that true by
-     * construction rather than by everyone remembering. See its docblock for
-     * why an allow-list beats the strip-list this used to be.
-     */
-    private static function sanitizeIdentifier(string $identifier): string
-    {
-        return SqlIdentifier::column($identifier, 'status');
-    }
 }

--- a/plugins/cartshift/tests/Unit/Migrator/Entity/WooStorageTest.php
+++ b/plugins/cartshift/tests/Unit/Migrator/Entity/WooStorageTest.php
@@ -115,47 +115,10 @@ final class WooStorageTest extends PluginTestCase
         $this->assertSame('', WooStorage::normalizeStatus('   '));
     }
 
-    public function testStatusInClauseQuotesEveryValue(): void
-    {
-        $clause = WooStorage::statusInClause(['wc-pending', 'wc-completed']);
 
-        $this->assertSame("status IN ('wc-pending', 'wc-completed')", $clause);
-    }
 
-    public function testStatusInClauseNormalizesAndDeduplicates(): void
-    {
-        $clause = WooStorage::statusInClause(['pending', 'wc-pending', 'completed']);
 
-        $this->assertSame("status IN ('wc-pending', 'wc-completed')", $clause);
-    }
 
-    public function testStatusInClauseMatchesNothingWhenEmpty(): void
-    {
-        $this->assertSame('1 = 0', WooStorage::statusInClause([]));
-    }
-
-    public function testStatusInClauseSanitizesTheColumnName(): void
-    {
-        $clause = WooStorage::statusInClause(['wc-pending'], 'o.status; DROP TABLE wp_posts');
-
-        // This used to assert `o.statusDROPTABLEwp_posts`, the strip-list's
-        // output: not an injection, but not a column either, so the query died
-        // at the database naming something nobody wrote. The allow-list asks
-        // the question that was actually being asked — is this a column
-        // reference? — and answers no, falling back to a valid one.
-        $this->assertStringNotContainsString(';', $clause);
-        $this->assertStringNotContainsString('DROP', $clause);
-        $this->assertSame("status IN ('wc-pending')", $clause);
-    }
-
-    public function testStatusInClauseKeepsAQualifiedColumn(): void
-    {
-        // The fallback must not swallow the legitimate case it exists to guard.
-        $this->assertSame(
-            "o.status IN ('wc-pending')",
-            WooStorage::statusInClause(['wc-pending'], 'o.status'),
-        );
-    }
 
     public function testOrderScopeClauseCombinesTypeAndStatus(): void
     {


### PR DESCRIPTION
Added in 1.2.0 (`0472ad1`) and never called since.

## "grep found no callers" is not evidence in this codebase

`PreflightCheck::detectHpos()` sets `$helper = '\CartShift\Support\WooStorage'` and reaches it through `class_exists()` / `method_exists()` / `$helper::isHposEnabled()`. A live method here can have **no textual caller at all** — which is exactly how `isHposEnabled` looks dead and is not.

My first pass reported six dead methods on this class. Four of them (`migratableOrderStatuses`, `migratableSubscriptionStatuses`, `normalizeStatus`, `orderScopeTemplate`) are live through internal `self::` calls, and `orderScopeClause` through two more. The pattern I grepped simply missed them.

The test that actually settles it is **the method name as a string**: dynamic dispatch has to spell it somewhere. `statusInClause` appears nowhere in this repository, the playground, or the sibling plugins outside its own definition and tests. No internal `self::` call either. `Migrations.php:44`'s `self::$method()` dispatches only from a fixed `VERSIONS` map and cannot reach WooStorage.

## It should go, not stay

It is a **second implementation of a rule that matters**. Every live path — `orderScopeSql`, `orderScopeParts`, `subscriptionScopeSql` — runs through `orderScopeTemplate`, which builds its own `status IN (...)` and its own empty-list guard. `statusInClause` built both again, separately.

Two spellings of *"an empty list must match nothing, not everything"* is the divergence class this release spent its time eliminating. And the parameterised column it offered has no consumer: orders and subscriptions both live in `wc_orders.status`.

`sanitizeIdentifier` goes with it — `statusInClause` was its only caller. Which means the allow-list I gave it an hour ago in #131 was hardening a dead path. The same change to `ScopePredicate` and `ProductTypes` stands, and `SqlIdentifier` keeps both of those as live users.

## Coverage is not thinned

The empty-list guard is asserted through the **real query paths** in `ScopedKeysetTest` and `CustomerCursorBoundaryTest`, not through the method being removed. So deleting its five tests removes duplicate coverage, not the only coverage.

**748 tests** from 753 — the five removed being exactly this method's. 233 vitest. Every remaining public method on WooStorage now has a caller, external or internal.